### PR TITLE
Make use of travis CI service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
     - master
 notifications:
   recipients:
-    - hennr@hennr.name
+    - your@devMailingList.here
   email:
-    on_success: always
+    on_success: change
     on_failure: always


### PR DESCRIPTION
Please merge this PR to make use of the free CI service Travis CI.

Note: You should replace the mail dummy address with your developer ML.

After pulling this, please follow: http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in
