### PR TITLE
Fix compile error on MacOSX

### DIFF
--- a/src/platform/OS.cpp
+++ b/src/platform/OS.cpp
@@ -162,7 +162,7 @@ std::string getOSName() {
 	#elif ARX_PLATFORM == ARX_PLATFORM_WIN32
 	return "Windows";
 	#elif ARX_PLATFORM == ARX_PLATFORM_MACOSX
-	return "Darwin"
+	return "Darwin";
 	#elif ARX_PLATFORM == ARX_PLATFORM_BSD
 	return "BSD";
 	#elif ARX_PLATFORM == ARX_PLATFORM_UNIX


### PR DESCRIPTION
when building on OS X 10.8.4 , compiler claims about missing ';' 
