### PR TITLE
Fix compilation on platforms without OpenAL EFX support.

### DIFF
--- a/src/audio/openal/OpenALBackend.cpp
+++ b/src/audio/openal/OpenALBackend.cpp
@@ -480,9 +480,8 @@ aalError OpenALBackend::setReverbEnabled(bool enable) {
 	return enable ? AAL_ERROR_SYSTEM : AAL_OK;
 }
 
-aalError OpenALBackend::setRoomRolloffFactor(float factor) {
-	ARX_UNUSED(factor);
-	return AAL_ERROR_INIT;
+bool OpenALBackend::isReverbSupported() {
+	return false;
 }
 
 aalError OpenALBackend::setListenerEnvironment(const Environment & env) {


### PR DESCRIPTION
Hi!

Compilation on Mac with 'master' branch is broken right now due to functions in OpenALBackend.cpp
I tried to fix it.
Please, take a look.

PS. What about using C++11/14 features? E.g. 'override' keyword. Is C++11 allowed?