### PR TITLE
Fix minor style errors

### DIFF
--- a/src/gui/widget/CheckboxWidget.h
+++ b/src/gui/widget/CheckboxWidget.h
@@ -44,7 +44,7 @@ public:
 	int					iState;
 	int					iOldState;
 	
-	boost::function<void(int)> stateChanged;
+	boost::function<void(int)> stateChanged;	// NOLINT
 	
 private:
 	TextureContainer * m_textureOff;

--- a/src/gui/widget/SliderWidget.cpp
+++ b/src/gui/widget/SliderWidget.cpp
@@ -28,7 +28,7 @@
 #include "input/Input.h"
 #include "scene/GameSound.h"
 
-SliderWidget::SliderWidget(Vec2i pos)
+SliderWidget::SliderWidget(const Vec2i & pos)
 	: Widget()
 {
 	m_id = BUTTON_INVALID;

--- a/src/gui/widget/SliderWidget.h
+++ b/src/gui/widget/SliderWidget.h
@@ -29,7 +29,7 @@
 class SliderWidget: public Widget {
 	
 public:
-	SliderWidget(Vec2i pos);
+	explicit SliderWidget(const Vec2i & pos);
 	virtual ~SliderWidget();
 	
 	void setMinimum(int minimum);
@@ -45,7 +45,7 @@ public:
 	void RenderMouseOver();
 	void EmptyFunction();
 	
-	boost::function<void(int)> valueChanged;
+	boost::function<void(int)> valueChanged;	// NOLINT
 	
 private:
 	ButtonWidget		*	pLeftButton;
@@ -53,8 +53,8 @@ private:
 	TextureContainer	* pTex1;
 	TextureContainer	* pTex2;
 	
-	int m_minimum;
-	int					m_value;
+	int	m_minimum;
+	int	m_value;
 };
 
 #endif // ARX_GUI_WIDGET_SLIDERWIDGET_H

--- a/src/gui/widget/TextWidget.h
+++ b/src/gui/widget/TextWidget.h
@@ -37,7 +37,7 @@ public:
 	Color lColorHighlight;
 	bool	bSelected;
 	
-	boost::function<void(TextWidget *)> clicked;
+	boost::function<void(TextWidget *)> clicked;	// NOLINT
 	
 public:
 	TextWidget(MenuButton id, Font * font, const std::string & text, Vec2i pos = Vec2i_ZERO);


### PR DESCRIPTION
Command `make style 2>&1 | grep ":"` gave me the following output:

src/gui/widget/CheckboxWidget.h:47:  All parameters should be named in a function  [readability/function] [3]
src/gui/widget/SliderWidget.h:32:  Single-argument constructors should be marked explicit.  [runtime/explicit] [5]
src/gui/widget/SliderWidget.h:48:  All parameters should be named in a function  [readability/function] [3]
src/gui/widget/TextWidget.h:40:  All parameters should be named in a function  [readability/function] [3]

Here I'm trying to fix those errors.