### PR TITLE
Prevent further script events only if Entity is destroyed

### DIFF
--- a/src/script/ScriptedIOControl.cpp
+++ b/src/script/ScriptedIOControl.cpp
@@ -660,10 +660,13 @@ public:
 		ARX_INTERACTIVE_DestroyIOdelayed(entity);
 		
 		// Prevent further script events as the object has been destroyed!
-		entity->show = SHOW_FLAG_MEGAHIDE;
-		entity->ioflags |= IO_FREEZESCRIPT;
-		if(entity == context.getEntity()) {
-			return AbortAccept;
+		// Object is destroyed only if its count is 1 or less
+		if(entity->_itemdata->count <= 1) {
+			entity->show = SHOW_FLAG_MEGAHIDE;
+			entity->ioflags |= IO_FREEZESCRIPT;
+			if(entity == context.getEntity()) {
+				return AbortAccept;
+			}
 		}
 		
 		return Success;


### PR DESCRIPTION
ARX_INTERACTIVE_DestroyIOdelayed() destroys an Entity only if its count is 1 or less. Script events are thus disabled only for soon-to-be-destroyed Entities.

Fixes: bug #751