### PR TITLE
Load a game on Resume and F9 to quickload in menu

### DIFF
--- a/src/core/ArxGame.cpp
+++ b/src/core/ArxGame.cpp
@@ -1312,14 +1312,14 @@ void ArxGame::doFrame() {
 	if(cinematicIsStopped()
 	   && !cinematicBorder.isActive()
 	   && !BLOCK_PLAYER_CONTROLS
-	   && ARXmenu.currentmode == AMCM_OFF
 	) {
 		
-		if(GInput->actionNowPressed(CONTROLS_CUST_QUICKLOAD)) {
+		if(GInput->actionNowPressed(CONTROLS_CUST_QUICKLOAD) && savegames.size() > 0) {
+			ARXmenu.currentmode = AMCM_OFF;
 			ARX_QuickLoad();
 		}
 		
-		if(GInput->actionNowPressed(CONTROLS_CUST_QUICKSAVE)) {
+		if(GInput->actionNowPressed(CONTROLS_CUST_QUICKSAVE) && ARXmenu.currentmode == AMCM_OFF) {
 			g_hudRoot.quickSaveIconGui.show();
 			GRenderer->getSnapshot(savegame_thumbnail, config.interface.thumbnailSize.x, config.interface.thumbnailSize.y);
 			ARX_QuickSave();

--- a/src/gui/MainMenu.cpp
+++ b/src/gui/MainMenu.cpp
@@ -1777,7 +1777,11 @@ void MainMenu::init()
 
 void MainMenu::onClickedResumeGame(){
 	pTextManage->Clear();
-	ARXMenu_ResumeGame();
+	if(!g_canResumeGame) {
+		ARX_QuickLoad();
+	} else {
+		ARXMenu_ResumeGame();
+	}
 }
 
 void MainMenu::onClickedNewQuest() {
@@ -1797,7 +1801,7 @@ MENUSTATE MainMenu::Update() {
 		if(g_canResumeGame) {
 			m_resumeGame->SetCheckOn();
 			m_resumeGame->lColor = Color(232, 204, 142);
-		} else {
+		} else if(savegames.size() == 0) {
 			m_resumeGame->SetCheckOff();
 			m_resumeGame->lColor = Color(127, 127, 127);
 		}


### PR DESCRIPTION
Implements both features in Feature request #45. 

I'm not entirely sure if one doesn't need to do other operations before loading a game using ARXMenu_LoadQuest() and ARX_Quickload(), so if anything's wrong, just let me know and I'll modify it accordingly.