### PR TITLE
Change SaveGameList::quickload() to load only the latest quicksave

### DIFF
--- a/src/core/SaveGame.cpp
+++ b/src/core/SaveGame.cpp
@@ -278,7 +278,12 @@ SaveGameList::iterator SaveGameList::quickload() {
 		return end();
 	}
 	
-	// update() already sorts the savegame list so we can just return the first one.
-	
-	return begin();
+	// update() already sorts the savegame list so we can just return the first quicksave
+	for(unsigned int i=0; i < savelist.size(); i++) {
+		if(savelist[i].quicksave) {
+			return savelist.begin() + i;
+		}
+	}
+	//no quicksave found, results in no game loaded in ARX_QuickLoad()
+	return end();
 }


### PR DESCRIPTION
Previously, the method would load the last saved game, regardless of save type. This changes its behavior to be more like current games, where quickload chooses the latest save among quicksaves only.

I believe this change would make its behavior more predictable and up to par with modern games.