### PR TITLE
Fix 2D cinematics starting at wrong times

### DIFF
--- a/src/cinematic/CinematicController.cpp
+++ b/src/cinematic/CinematicController.cpp
@@ -142,9 +142,12 @@ bool isInCinematic() {
 
 // Manages Currently playing 2D cinematic
 void cinematicRender() {
-	
+
+	PlatformDuration diff = g_platformTime.lastFrameDuration();
+
 	if(PLAY_LOADED_CINEMATIC == Cinematic_StartRequested) {
 		LogDebug("really starting cinematic now");
+		diff = PlatformDuration_ZERO;
 		PLAY_LOADED_CINEMATIC = Cinematic_Started;
 	}
 
@@ -152,7 +155,7 @@ void cinematicRender() {
 	ControlCinematique->InitDeviceObjects();
 	GRenderer->SetRenderState(Renderer::AlphaBlending, true);
 
-	ControlCinematique->Render(g_platformTime.lastFrameDuration());
+	ControlCinematique->Render(diff);
 
 	// end the animation
 	if(   !ControlCinematique->key


### PR DESCRIPTION
Broken in 1142038e4. Cines starting after level load would start several seconds into them, missing pictures and sounds. This fixes them so they start at 0 time and progress with lastFrameDuration() as before.