### PR TITLE
Fix softlock after cancelling cinematic

### DIFF
--- a/src/script/ScriptedControl.cpp
+++ b/src/script/ScriptedControl.cpp
@@ -227,6 +227,7 @@ public:
 		
 		if(name == "kill") {
 			cinematicKill();
+			arxtime.resume();
 		} else if(name == "play") {
 			cinematicRequestStart();
 			arxtime.pause();


### PR DESCRIPTION
Cinematics started between cutscenes would lock the game up due to missing GameTime::resume() call.

Fixes Issue #905