### PR TITLE
Use platform time for magic flares

### DIFF
--- a/src/game/Spells.cpp
+++ b/src/game/Spells.cpp
@@ -548,7 +548,7 @@ void ARX_SPELLS_ManageMagic() {
 					pos = Vec2f(MemoMouse);
 				}
 				
-				ArxInstant now = arxtime.now();
+				ArxInstant now = ArxInstant(platform::getTimeMs());
 				
 				const ArxDuration interval = ArxDurationMs(1000 / 60);
 				

--- a/src/graphics/particle/MagicFlare.cpp
+++ b/src/graphics/particle/MagicFlare.cpp
@@ -373,7 +373,7 @@ void ARX_MAGICAL_FLARES_Update() {
 		shinum = 1;
 	}
 	
-	float diff = arxtime.get_frame_delay();
+	float diff = toMs(g_platformTime.lastFrameDuration());
 	
 	bool key = !GInput->actionPressed(CONTROLS_CUST_MAGICMODE);
 


### PR DESCRIPTION
Magic flares now animate during Freeze Time spell and debug pause.