### PR TITLE
Interactive: Fix flares showing through activated objects

### DIFF
--- a/src/scene/Interactive.cpp
+++ b/src/scene/Interactive.cpp
@@ -1875,7 +1875,7 @@ Entity * GetFirstInterAtPos(const Vec2s & pos, long flag, Vec3f * _pRef, Entity 
 		if((io->ioflags & IO_CAMERA) || (io->ioflags & IO_MARKER))
 			continue;
 
-		if(!(io->gameFlags & GFLAG_INTERACTIVITY))
+		if(!flag && !(io->gameFlags & GFLAG_INTERACTIVITY))
 			continue;
 
 		// Is Object in TreatZone ??


### PR DESCRIPTION
Flares are no longer visible through doors while lockpicking or opening/closing them.