### PR TITLE
HUD collisions & improvements

### DIFF
--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -313,7 +313,7 @@ bool Manage3DCursor(Entity * io, bool simulate) {
 
 extern long LOOKING_FOR_SPELL_TARGET;
 extern ArxInstant LOOKING_FOR_SPELL_TARGET_TIME;
-extern bool PLAYER_INTERFACE_HIDE_COUNT;
+extern bool PLAYER_INTERFACE_SHOW;
 extern long lCursorRedistValue;
 
 int iHighLight=0;
@@ -428,7 +428,7 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 		return;
 	}
 	
-	if(!(flag || (!BLOCK_PLAYER_CONTROLS && PLAYER_INTERFACE_HIDE_COUNT))) {
+	if(!(flag || (!BLOCK_PLAYER_CONTROLS && PLAYER_INTERFACE_SHOW))) {
 		return;
 	}
 		

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1362,7 +1362,7 @@ void StealthGauge::draw() {
 	GRenderer->SetRenderState(Renderer::AlphaBlending, false);
 }
 
-bool PLAYER_INTERFACE_HIDE_COUNT = true;
+bool PLAYER_INTERFACE_SHOW = true;
 
 PlayerInterfaceFader::PlayerInterfaceFader()
 	: m_direction(0)
@@ -1371,7 +1371,7 @@ PlayerInterfaceFader::PlayerInterfaceFader()
 
 void PlayerInterfaceFader::reset() {
 	m_direction = 0;
-	PLAYER_INTERFACE_HIDE_COUNT = true;
+	PLAYER_INTERFACE_SHOW = true;
 }
 
 void PlayerInterfaceFader::resetSlid() {
@@ -1386,9 +1386,9 @@ void PlayerInterfaceFader::requestFade(FadeDirection showhide, long smooth) {
 	}
 	
 	if(showhide == FadeDirection_In) {
-		PLAYER_INTERFACE_HIDE_COUNT = true;
+		PLAYER_INTERFACE_SHOW = true;
 	} else {
-		PLAYER_INTERFACE_HIDE_COUNT = false;
+		PLAYER_INTERFACE_SHOW = false;
 	}
 	
 	if(smooth) {
@@ -1412,7 +1412,7 @@ PlatformInstant SLID_START = PlatformInstant_ZERO; // Charging Weapon
 
 void PlayerInterfaceFader::update() {
 	
-	if(PLAYER_INTERFACE_HIDE_COUNT && !m_direction) {
+	if(PLAYER_INTERFACE_SHOW && !m_direction) {
 		bool bOk = true;
 		
 		if(TRUE_PLAYER_MOUSELOOK_ON) {

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -152,7 +152,7 @@ void HitStrengthGauge::update() {
 			const float delta = toMs(player.m_aimTime);
 			float at = delta;
 			float aim = static_cast<float>(player.Full_AimTime);
-			j=at/aim;
+			j = at / aim;
 		}
 		m_intensity = glm::clamp(j, 0.2f, 1.f);
 	}
@@ -1550,7 +1550,7 @@ void HudRoot::draw() {
 	if(!(player.Interface & INTER_COMBATMODE) && (player.Interface & INTER_MINIBACK)) {
 		
 		if(player.Interface & INTER_STEAL) {
-			stealIconGui.draw();			
+			stealIconGui.draw();
 		}
 	}
 	

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1305,8 +1305,11 @@ void StealthGauge::init() {
 	m_size = Vec2f(32.f, 32.f);
 }
 
-void StealthGauge::update(const Rectf & parent) {
+void StealthGauge::updateRect(const Rectf & parent) {
 	m_rect = createChild(parent, Anchor_TopRight, m_size * m_scale, Anchor_BottomLeft);
+}
+
+void StealthGauge::update() {
 	
 	m_visible = false;
 	
@@ -1490,7 +1493,8 @@ void HudRoot::draw() {
 	spacer.top = spacer.bottom - 30;
 	spacer.right = spacer.left + 20;
 	
-	stealthGauge.update(spacer);
+	stealthGauge.updateRect(spacer);
+	stealthGauge.update();
 	
 	damagedEquipmentGui.updateRect(stealthGauge.rect());
 	damagedEquipmentGui.update();

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1035,7 +1035,7 @@ void PrecastSpellsGui::update() {
 		Color color = Color3f(0, val * (1.0f/2), val).to<u8>();
 		
 		Rectf childRect = createChild(m_rect, Anchor_BottomLeft, m_iconSize * m_scale, Anchor_BottomLeft);
-		childRect.move(i * 33 * m_scale, 0);
+		childRect.move(i * m_iconSize.x * m_scale, 0);
 		
 		SpellType typ = precastSlot.typ;
 		

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1469,6 +1469,7 @@ void HudRoot::draw() {
 	hitStrengthGauge.update();
 	
 	g_secondaryInventoryHud.update();
+	g_secondaryInventoryHud.updateRect();
 	g_playerInventoryHud.updateRect();
 	g_secondaryInventoryHud.updateFader();
 	g_playerInventoryHud.update();

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -525,7 +525,6 @@ void PurseIconGui::draw() {
 CurrentTorchIconGui::CurrentTorchIconGui()
 	: HudItem()
 	, m_isActive(false)
-	, m_rect()
 	, m_tex(NULL)
 	, m_size()
 {}

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -63,6 +63,9 @@
 
 extern bool WILLRETURNTOFREELOOK;
 
+static const int indicatorVertSpacing = 30;
+static const int indicatorHorizSpacing = 20;
+
 static void DrawItemPrice() {
 	
 	Entity *temp = SecondaryInventory->io;
@@ -1005,6 +1008,10 @@ void PrecastSpellsGui::updateRect(const Rectf & parent) {
 	Vec2f size = m_iconSize * Vec2f(Precast.size(), 1);
 	
 	m_rect = createChild(parent, Anchor_BottomRight, size * m_scale, Anchor_BottomLeft);
+	
+	if(g_playerInventoryHud.rect().overlaps(m_rect + Vec2f(0.0f, indicatorVertSpacing))) {
+		m_rect.move(0.0f, g_playerInventoryHud.rect().top - parent.bottom - indicatorVertSpacing);
+	}
 }
 
 void PrecastSpellsGui::update() {
@@ -1237,6 +1244,14 @@ void DamagedEquipmentGui::init() {
 
 void DamagedEquipmentGui::updateRect(const Rectf & parent) {
 	m_rect = createChild(parent, Anchor_BottomRight, m_size * m_scale, Anchor_BottomLeft);
+	
+	if(g_playerInventoryHud.rect().overlaps(m_rect + Vec2f(0.0f, indicatorVertSpacing))) {
+		m_rect.move(0.0f, g_playerInventoryHud.rect().top - parent.bottom - indicatorVertSpacing);
+	}
+
+	if(g_secondaryInventoryHud.rect().overlaps(m_rect  + Vec2f(0.0f, -indicatorHorizSpacing))) {
+		m_rect.move(g_secondaryInventoryHud.rect().right - m_rect.left + indicatorHorizSpacing, 0.0f);
+	}
 }
 
 void DamagedEquipmentGui::update() {
@@ -1307,6 +1322,14 @@ void StealthGauge::init() {
 
 void StealthGauge::updateRect(const Rectf & parent) {
 	m_rect = createChild(parent, Anchor_TopRight, m_size * m_scale, Anchor_BottomLeft);
+	
+	if(g_playerInventoryHud.rect().overlaps(m_rect + Vec2f(0.0f, indicatorVertSpacing))) {
+		m_rect.move(0.0f, g_playerInventoryHud.rect().top - parent.top - indicatorVertSpacing);
+	}
+	
+	if(g_secondaryInventoryHud.rect().overlaps(m_rect  + Vec2f(0.0f, -indicatorHorizSpacing))) {
+		m_rect.move(g_secondaryInventoryHud.rect().right - m_rect.left + indicatorHorizSpacing, 0.0f);
+	}
 }
 
 void StealthGauge::update() {
@@ -1484,14 +1507,11 @@ void HudRoot::draw() {
 	
 	quickSaveIconGui.update();
 	
-	
-	Vec2f anchorPos = g_playerInventoryHud.anchorPosition();
-	
 	Rectf spacer;
-	spacer.left = std::max(g_secondaryInventoryHud.rect().right, healthGauge.rect().right);
-	spacer.bottom = anchorPos.y;
-	spacer.top = spacer.bottom - 30;
-	spacer.right = spacer.left + 20;
+	spacer.left = healthGauge.rect().right;
+	spacer.bottom = g_size.bottom;
+	spacer.top = spacer.bottom - indicatorVertSpacing;
+	spacer.right = spacer.left + indicatorHorizSpacing;
 	
 	stealthGauge.updateRect(spacer);
 	stealthGauge.update();

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -540,12 +540,10 @@ bool CurrentTorchIconGui::isVisible() {
 
 void CurrentTorchIconGui::updateRect(const Rectf & parent) {
 	
-	float secondaryInventoryX = g_secondaryInventoryHud.m_fadePosition + 110.f;
-	
 	m_rect = createChild(parent, Anchor_TopLeft, m_size * m_scale, Anchor_BottomLeft);
 	
-	if(m_rect.left < secondaryInventoryX) {
-		m_rect.move(secondaryInventoryX, 0.f);
+	if(m_rect.left < g_secondaryInventoryHud.rect().right) {
+		m_rect.move(g_secondaryInventoryHud.rect().right, 0.f);
 	}
 }
 

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1485,7 +1485,7 @@ void HudRoot::draw() {
 	Vec2f anchorPos = g_playerInventoryHud.anchorPosition();
 	
 	Rectf spacer;
-	spacer.left = std::max(g_secondaryInventoryHud.m_fadePosition + 160, healthGauge.rect().right);
+	spacer.left = std::max(g_secondaryInventoryHud.rect().right, healthGauge.rect().right);
 	spacer.bottom = anchorPos.y;
 	spacer.top = spacer.bottom - 30;
 	spacer.right = spacer.left + 20;

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1469,6 +1469,7 @@ void HudRoot::draw() {
 	hitStrengthGauge.update();
 	
 	g_secondaryInventoryHud.update();
+	g_playerInventoryHud.updateRect();
 	g_secondaryInventoryHud.updateFader();
 	g_playerInventoryHud.update();
 	mecanismIcon.update();

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -150,9 +150,8 @@ void HitStrengthGauge::update() {
 			j = player.m_bowAimRatio;
 		} else {
 			const float delta = toMs(player.m_aimTime);
-			float at = delta;
 			float aim = static_cast<float>(player.Full_AimTime);
-			j = at / aim;
+			j = delta / aim;
 		}
 		m_intensity = glm::clamp(j, 0.2f, 1.f);
 	}

--- a/src/gui/Hud.h
+++ b/src/gui/Hud.h
@@ -364,7 +364,8 @@ public:
 	StealthGauge();
 	
 	void init();
-	void update(const Rectf & parent);
+	void updateRect(const Rectf & parent);
+	void update();
 	void draw();
 };
 

--- a/src/gui/Hud.h
+++ b/src/gui/Hud.h
@@ -132,7 +132,6 @@ public:
 class CurrentTorchIconGui : public HudItem {
 private:
 	bool m_isActive;
-	Rectf m_rect;
 	TextureContainer * m_tex;
 	Vec2f m_size;
 	

--- a/src/gui/hud/PlayerInventory.cpp
+++ b/src/gui/hud/PlayerInventory.cpp
@@ -64,6 +64,18 @@ Vec2f PlayerInventoryHud::anchorPosition() {
 	g_size.height() - (101 * m_scale) + (InventoryY * m_scale));
 }
 
+void PlayerInventoryHud::updateRect(){
+	
+	Vec2f anchorPos = anchorPosition();
+	
+	if(player.Interface & INTER_INVENTORYALL) {
+		m_rect = Rectf(anchorPos - Vec2f(0, (player.bag - 1) * m_bagBackgroundSize.y * m_scale), 
+		                                 m_bagBackgroundSize.x * m_scale, player.bag * m_bagBackgroundSize.y * m_scale);
+	} else {
+		m_rect = Rectf(anchorPos, m_bagBackgroundSize.x * m_scale, m_bagBackgroundSize.y * m_scale);
+	}
+}
+
 bool PlayerInventoryHud::updateInput() {
 	Vec2f anchorPos = anchorPosition();
 	

--- a/src/gui/hud/PlayerInventory.h
+++ b/src/gui/hud/PlayerInventory.h
@@ -48,6 +48,7 @@ public:
 	void init();
 	Vec2f anchorPosition();
 	void update();
+	void updateRect();
 	bool updateInput();
 	void draw();
 	

--- a/src/gui/hud/SecondaryInventory.cpp
+++ b/src/gui/hud/SecondaryInventory.cpp
@@ -182,6 +182,11 @@ void SecondaryInventoryHud::update() {
 	}
 }
 
+void SecondaryInventoryHud::updateRect() {
+	
+	m_rect = Rectf(Vec2f(m_fadePosition * m_scale, 0.f), m_size.x * m_scale, m_size.y * m_scale);
+}
+
 void SecondaryInventoryHud::draw() {
 	const INVENTORY_DATA * inventory = TSecondaryInventory;
 	
@@ -200,8 +205,7 @@ void SecondaryInventoryHud::draw() {
 			ingame_inventory = tc;
 	}
 	
-	Rectf rect = Rectf(Vec2f(m_fadePosition * m_scale, 0.f), m_size.x * m_scale, m_size.y * m_scale);
-	EERIEDrawBitmap(rect, 0.001f, ingame_inventory, Color::white);
+	EERIEDrawBitmap(m_rect, 0.001f, ingame_inventory, Color::white);
 	
 	for(long y = 0; y < inventory->m_size.y; y++) {
 		for(long x = 0; x < inventory->m_size.x; x++) {

--- a/src/gui/hud/SecondaryInventory.cpp
+++ b/src/gui/hud/SecondaryInventory.cpp
@@ -171,13 +171,12 @@ void SecondaryInventoryHud::update() {
 		// Pick All/Close Secondary Inventory
 		if(TSecondaryInventory) {
 			//These have to be calculated on each frame (to make them move).
-			Rectf parent = Rectf(Vec2f(m_fadePosition, 0), m_defaultBackground->m_size.x * m_scale, m_defaultBackground->m_size.y * m_scale);
 			
 			m_pickAllButton.setScale(m_scale);
 			m_closeButton.setScale(m_scale);
 			
-			m_pickAllButton.update(parent);
-			m_closeButton.update(parent);
+			m_pickAllButton.update(m_rect);
+			m_closeButton.update(m_rect);
 		}
 	}
 }

--- a/src/gui/hud/SecondaryInventory.h
+++ b/src/gui/hud/SecondaryInventory.h
@@ -61,6 +61,7 @@ private:
 public:
 	void init();
 	void update();
+	void updateRect();
 	void draw();
 	
 	void updateInputButtons();

--- a/src/math/Rectangle.h
+++ b/src/math/Rectangle.h
@@ -127,7 +127,7 @@ public:
 	}
 	
 	bool overlaps(const Rectangle_ & other) const {
-		return (left < other.right && other.left < right && top < other.bottom && bottom < other.top);
+		return (left < other.right && other.left < right && top < other.bottom && bottom > other.top);
 	}
 	
 	/*!


### PR DESCRIPTION
Individual bottom left indicators are now moved when they collide with player and secondary inventories + several related and unrelated HUD fixes.