### PR TITLE
Use HUD scale for item icons and cursors

### DIFF
--- a/src/core/ArxGame.cpp
+++ b/src/core/ArxGame.cpp
@@ -1181,7 +1181,7 @@ void ArxGame::onWindowGotFocus(const Window &) {
 void ArxGame::onWindowLostFocus(const Window &) {
 	
 	// TODO(option-control) add a config option for this
-	ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
+	ARX_INTERFACE_setCombatMode(COMBAT_MODE_OFF);
 	TRUE_PLAYER_MOUSELOOK_ON = false;
 	PLAYER_MOUSELOOK_ON = false;
 	

--- a/src/core/ArxGame.cpp
+++ b/src/core/ArxGame.cpp
@@ -1181,7 +1181,7 @@ void ArxGame::onWindowGotFocus(const Window &) {
 void ArxGame::onWindowLostFocus(const Window &) {
 	
 	// TODO(option-control) add a config option for this
-	ARX_INTERFACE_Combat_Mode(0);
+	ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
 	TRUE_PLAYER_MOUSELOOK_ON = false;
 	PLAYER_MOUSELOOK_ON = false;
 	

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -86,6 +86,7 @@ const bool
 	colorkeyAntialiasing = true,
 	limitSpeechWidth = true,
 	hudScaleInteger = true,
+	scaleCursorWithHud = false,
 	minimizeOnFocusLost = true,
 	eax = true,
 	muteOnFocusLost = false,
@@ -194,6 +195,7 @@ const std::string
 	cinematicWidescreenMode = "cinematic_widescreen_mode",
 	hudScale = "hud_scale",
 	hudScaleInteger = "hud_scale_integer",
+	scaleCursorWithHud = "scale_cursor_with_hud",
 	hudScaleFilter = "hud_scale_filter",
 	thumbnailSize = "save_thumbnail_size";
 
@@ -416,6 +418,7 @@ bool Config::save() {
 	writer.writeKey(Key::cinematicWidescreenMode, int(interface.cinematicWidescreenMode));
 	writer.writeKey(Key::hudScale, interface.hudScale);
 	writer.writeKey(Key::hudScaleInteger, interface.hudScaleInteger);
+	writer.writeKey(Key::scaleCursorWithHud, interface.scaleCursorWithHud);
 	writer.writeKey(Key::hudScaleFilter, interface.hudScaleFilter);
 	std::ostringstream osst;
 	osst << interface.thumbnailSize.x << 'x' << interface.thumbnailSize.y;
@@ -550,6 +553,7 @@ bool Config::init(const fs::path & file) {
 	float hudScale = reader.getKey(Section::Interface, Key::hudScale, Default::hudScale);
 	interface.hudScale = glm::clamp(hudScale, 0.f, 1.f);
 	interface.hudScaleInteger = reader.getKey(Section::Interface, Key::hudScaleInteger, Default::hudScaleInteger);
+	interface.scaleCursorWithHud = reader.getKey(Section::Interface, Key::scaleCursorWithHud, Default::scaleCursorWithHud);
 	int hudScaleFilter = reader.getKey(Section::Interface, Key::hudScaleFilter, Default::hudScaleFilter);
 	interface.hudScaleFilter = UIScaleFilter(glm::clamp(hudScaleFilter, 0, 1));
 	std::string thumbnailSize = reader.getKey(Section::Interface, Key::thumbnailSize, Default::thumbnailSize);

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -139,6 +139,7 @@ public:
 		
 		float hudScale;
 		bool hudScaleInteger;
+		bool scaleCursorWithHud;
 		UIScaleFilter hudScaleFilter;
 		
 		Vec2i thumbnailSize;

--- a/src/game/Inventory.cpp
+++ b/src/game/Inventory.cpp
@@ -1280,7 +1280,7 @@ void ARX_INVENTORY_OpenClose(Entity * _io)
 		}
 
 		if(player.Interface & INTER_COMBATMODE) {
-			ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
+			ARX_INTERFACE_setCombatMode(COMBAT_MODE_OFF);
 		}
 
 		if(!config.input.autoReadyWeapon) {

--- a/src/game/Inventory.cpp
+++ b/src/game/Inventory.cpp
@@ -1280,7 +1280,7 @@ void ARX_INVENTORY_OpenClose(Entity * _io)
 		}
 
 		if(player.Interface & INTER_COMBATMODE) {
-			ARX_INTERFACE_Combat_Mode(0);
+			ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
 		}
 
 		if(!config.input.autoReadyWeapon) {

--- a/src/game/Spells.cpp
+++ b/src/game/Spells.cpp
@@ -513,7 +513,7 @@ void ARX_SPELLS_ManageMagic() {
 		if(player.Interface & INTER_COMBATMODE) {
 			WILLRETURNTOCOMBATMODE = true;
 
-			ARX_INTERFACE_Combat_Mode(0);
+			ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
 
 			ResetAnim(io->animlayer[1]);
 			io->animlayer[1].flags &= ~EA_LOOP;

--- a/src/game/Spells.cpp
+++ b/src/game/Spells.cpp
@@ -513,7 +513,7 @@ void ARX_SPELLS_ManageMagic() {
 		if(player.Interface & INTER_COMBATMODE) {
 			WILLRETURNTOCOMBATMODE = true;
 
-			ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
+			ARX_INTERFACE_setCombatMode(COMBAT_MODE_OFF);
 
 			ResetAnim(io->animlayer[1]);
 			io->animlayer[1].flags &= ~EA_LOOP;

--- a/src/game/magic/Precast.cpp
+++ b/src/game/magic/Precast.cpp
@@ -112,7 +112,7 @@ void ARX_SPELLS_Precast_Check() {
 			
 			if(player.Interface & INTER_COMBATMODE) {
 				WILLRETURNTOCOMBATMODE = true;
-				ARX_INTERFACE_Combat_Mode(0);
+				ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
 				ResetAnim(layer1);
 				layer1.flags &= ~EA_LOOP;
 			}

--- a/src/game/magic/Precast.cpp
+++ b/src/game/magic/Precast.cpp
@@ -112,7 +112,7 @@ void ARX_SPELLS_Precast_Check() {
 			
 			if(player.Interface & INTER_COMBATMODE) {
 				WILLRETURNTOCOMBATMODE = true;
-				ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
+				ARX_INTERFACE_setCombatMode(COMBAT_MODE_OFF);
 				ResetAnim(layer1);
 				layer1.flags &= ~EA_LOOP;
 			}

--- a/src/game/magic/RuneDraw.cpp
+++ b/src/game/magic/RuneDraw.cpp
@@ -32,7 +32,7 @@ extern EERIE_CAMERA subj;
 
 static const Vec2s symbolVecScale(8*2, 6*2);
 
-SYMBOL_DRAW bookSymbolDraw;
+SYMBOL_DRAW g_bookSymbolDraw;
 
 
 static Vec2s GetSymbVector(char c) {
@@ -107,13 +107,13 @@ static void updateIOLight(Entity * io) {
 
 void ARX_SPELLS_UpdateBookSymbolDraw(Rect rect) {
 
-	if(bookSymbolDraw.sequence.empty()) {
+	if(g_bookSymbolDraw.sequence.empty()) {
 		return;
 	}
 	
 	ArxInstant now = arxtime.now();
 
-	SYMBOL_DRAW * sd = &bookSymbolDraw;
+	SYMBOL_DRAW * sd = &g_bookSymbolDraw;
 	AnimationDuration elapsed = toAnimationDuration(now - sd->starttime);
 	sd->elapsed = elapsed;
 
@@ -333,7 +333,7 @@ static void ARX_SPELLS_RequestSymbolDrawCommon(Entity * io, float duration,
 		
 		sd = io->symboldraw;
 	} else {
-		sd = &bookSymbolDraw;
+		sd = &g_bookSymbolDraw;
 	}
 
 	sd->duration = AnimationDurationMs(std::max(1l, long(duration)));

--- a/src/graphics/DrawLine.cpp
+++ b/src/graphics/DrawLine.cpp
@@ -175,6 +175,12 @@ void drawLine(const Vec3f & orgn, const Vec3f & dest, Color color, float zbias) 
 	drawLine(orgn, dest, color, color, zbias);
 }
 
+void drawLineCross(Vec2f v, float z, Color color, float size) {
+	float halfSize = size / 2.0f;
+	drawLine(Vec2f(v.x, v.y - halfSize), Vec2f(v.x, v.y + halfSize), z, color);
+	drawLine(Vec2f(v.x - halfSize, v.y), Vec2f(v.x + halfSize, v.y), z, color);
+}
+
 void drawLineCross(Vec3f v, Color c, float size) {
 	drawLine(v - Vec3f(size, 0, 0), v + Vec3f(size, 0, 0), c);
 	drawLine(v - Vec3f(0, size, 0), v + Vec3f(0, size, 0), c);

--- a/src/graphics/DrawLine.h
+++ b/src/graphics/DrawLine.h
@@ -33,6 +33,7 @@ void drawLine(const Vec3f & orgn, const Vec3f & dest, Color color1, Color color2
 void drawLineRectangle(const Rectf & rect, float z, Color col);
 void drawLineSphere(const Sphere & sphere, Color color);
 void drawLineCylinder(const Cylinder & cyl, Color col);
+void drawLineCross(Vec2f v, float z, Color color, float size);
 void drawLineCross(Vec3f v, Color c, float size = 1.f);
 
 #endif // ARX_GRAPHICS_DRAWLINE_H

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -51,6 +51,7 @@
 #include "scene/Interactive.h"
 #include "scene/GameSound.h"
 
+#include "gui/Hud.h"
 #include "gui/Interface.h"
 #include "gui/Text.h"
 #include "gui/Menu.h"
@@ -457,6 +458,8 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 			iHighLight = 0;
 		}
 	}
+
+	float iconScale = g_hudRoot.getScale();
 	
 	if(   SpecialCursor
 	   || !PLAYER_MOUSELOOK_ON
@@ -513,6 +516,7 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 					tc = COMBINE->m_icon;
 				
 				Vec2f size(tc->m_size.x, tc->m_size.y);
+				size *= iconScale;
 				
 				if(SpecialCursor == CURSOR_COMBINEON) {
 					EERIEDrawBitmap(Rectf(mousePos, size.x, size.y), .00001f, tc, Color::white);
@@ -522,7 +526,7 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 						
 						if(v > 0.f) {
 							long t = long(v);
-							Vec2f nuberOffset = Vec2f(-16, -10);
+							Vec2f nuberOffset = Vec2f(-16, -10) * iconScale;
 							ARX_INTERFACE_DrawNumber(mousePos + nuberOffset, t, 6, Color::cyan, 1.f);
 						}
 					}

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -707,7 +707,8 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 			
 			Vec2f pos = Vec2f(g_size.center()) - Vec2f(surf->m_size) * .5f;
 			
-			EERIEDrawBitmap(Rectf(pos, float(surf->m_size.x), float(surf->m_size.y)), 0.f, surf, Color3f::gray(.5f).to<u8>());
+			Vec2f size = Vec2f(surf->m_size) * cursorScale;
+			EERIEDrawBitmap(Rectf(pos, size.x, size.y), 0.f, surf, Color3f::gray(.5f).to<u8>());
 			
 			GRenderer->SetRenderState(Renderer::AlphaBlending, false);
 		}

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -669,8 +669,10 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 						if(CANNOT_PUT_IT_HERE == EntityMoveCursor_Throw)
 							tcc = cursorThrowObject;
 						
-						if(tcc && tcc != tc) // to avoid movable double red cross...
-							EERIEDrawBitmap(Rectf(Vec2f(pos.x + 16, pos.y), float(tcc->m_size.x), float(tcc->m_size.y)), 0.00001f, tcc, Color::white);
+						if(tcc && tcc != tc) { // to avoid movable double red cross...
+							Vec2f size = Vec2f(tcc->m_size) * cursorScale;
+							EERIEDrawBitmap(Rectf(Vec2f(pos.x + 16, pos.y), size.x, size.y), 0.00001f, tcc, Color::white);
+						}
 					}
 					
 					if(haloTc) {

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -589,8 +589,8 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 				
 				UNICODE_ARXDrawTextCenter(hFontInBook, textPos, ss.str(), Color::black);
 			} else {
-				
-				EERIEDrawBitmap(Rectf(mousePos, float(surf->m_size.x), float(surf->m_size.y)), 0.f, surf, Color::white);
+				Vec2f size = Vec2f(surf->m_size) * cursorScale;
+				EERIEDrawBitmap(Rectf(mousePos, size.x, size.y), 0.f, surf, Color::white);
 			}
 			
 			SpecialCursor = 0;
@@ -681,7 +681,8 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 					TextureContainer * surf = cursorAnimatedHand.getCurrentTexture();
 					
 					if(surf) {
-						EERIEDrawBitmap(Rectf(mousePos, float(surf->m_size.x), float(surf->m_size.y)), 0.f, surf, Color::white);
+						Vec2f size = Vec2f(surf->m_size) * cursorScale;
+						EERIEDrawBitmap(Rectf(mousePos, size.x, size.y), 0.f, surf, Color::white);
 					}
 				}
 			}

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -460,6 +460,11 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 	}
 
 	float iconScale = g_hudRoot.getScale();
+	float cursorScale = 1.0f;
+	
+	if(config.interface.scaleCursorWithHud) {
+		cursorScale = g_hudRoot.getScale();
+	}
 	
 	if(   SpecialCursor
 	   || !PLAYER_MOUSELOOK_ON
@@ -611,6 +616,7 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 				}
 				
 				Vec2f size(surf->m_size.x, surf->m_size.y);
+				size *= cursorScale;
 				
 				pos += -size * 0.5f;
 				

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -636,13 +636,14 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 						pos = MemoMouse;
 					}
 					
-					Rectf rect(pos, float(tc->m_size.x), float(tc->m_size.y));
+					Vec2f size = Vec2f(tc->m_size) * iconScale;
+					Rectf rect(pos, size.x, size.y);
 					
 					if(!(DRAGINTER->ioflags & IO_MOVABLE)) {
 						EERIEDrawBitmap(rect, .00001f, tc, color);
 						
 						if((DRAGINTER->ioflags & IO_ITEM) && DRAGINTER->_itemdata->count != 1) {
-							Vec2f nuberOffset = Vec2f(2.f, 13.f);
+							Vec2f nuberOffset = Vec2f(2.f, 13.f) * iconScale;
 							ARX_INTERFACE_DrawNumber(pos + nuberOffset, DRAGINTER->_itemdata->count, 3, Color::white, 1.f);
 						}
 					} else {
@@ -667,7 +668,7 @@ static void ARX_INTERFACE_RenderCursorInternal(bool flag) {
 					}
 					
 					if(haloTc) {
-						ARX_INTERFACE_HALO_Draw(DRAGINTER, tc, haloTc, pos, Vec2f(1));
+						ARX_INTERFACE_HALO_Draw(DRAGINTER, tc, haloTc, pos, Vec2f(iconScale));
 					}
 				} else {
 					cursorAnimatedHand.update2();

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -706,8 +706,13 @@ void ARX_INTERFACE_RenderCursor(bool flag) {
 	
 	if (!SPECIAL_DRAGINTER_RENDER)
 	{
-		GRenderer->GetTextureStage(0)->setMinFilter(TextureStage::FilterNearest);
-		GRenderer->GetTextureStage(0)->setMagFilter(TextureStage::FilterNearest);
+		
+		TextureStage::FilterMode filter = TextureStage::FilterLinear;
+		if(config.interface.hudScaleFilter == UIFilterNearest) {
+			filter = TextureStage::FilterNearest;
+		}
+		GRenderer->GetTextureStage(0)->setMinFilter(filter);
+		GRenderer->GetTextureStage(0)->setMagFilter(filter);
 		GRenderer->GetTextureStage(0)->setWrapMode(TextureStage::WrapClamp);
 	}
 

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1698,6 +1698,10 @@ void HudRoot::setScale(float scale) {
 	g_secondaryInventoryHud.setScale(scale);
 }
 
+float HudRoot::getScale() {
+	return m_scale;
+}
+
 void HudRoot::init() {
 	changeLevelIconGui.init();
 	currentTorchIconGui.init();

--- a/src/gui/Hud.h
+++ b/src/gui/Hud.h
@@ -393,6 +393,7 @@ public:
 class HudRoot : public HudItem {
 public:
 	void setScale(float scale);
+	float getScale();
 	
 	void init();
 	void updateInput();

--- a/src/gui/Interface.cpp
+++ b/src/gui/Interface.cpp
@@ -856,14 +856,14 @@ static void GetInfosCombine() {
 // 1 to force Combat Mode On
 // 0 to force Combat Mode Off
 //-----------------------------------------------------------------------------
-void ARX_INTERFACE_Combat_Mode(long i) {
+void ARX_INTERFACE_Combat_Mode(ARX_INTERFACE_COMBAT_MODE i) {
 	arx_assert(entities.player());
 	arx_assert(arrowobj);
 	
 	if(i >= 1 && (player.Interface & INTER_COMBATMODE))
 		return;
 
-	if(i == 0 && !(player.Interface & INTER_COMBATMODE))
+	if(i == COMBAT_MODE_OFF && !(player.Interface & INTER_COMBATMODE))
 		return;
 
 	if((player.Interface & INTER_COMBATMODE)) {
@@ -1320,7 +1320,7 @@ void ArxGame::managePlayerControls() {
 
 		if(bGo) {
 			if(player.Interface & INTER_COMBATMODE) {
-				ARX_INTERFACE_Combat_Mode(0);
+				ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
 				SPECIAL_DRAW_WEAPON=0;
 
 				if(config.input.mouseLookToggle)
@@ -1330,7 +1330,7 @@ void ArxGame::managePlayerControls() {
 				SPECIAL_DRAW_WEAPON=1;
 				TRUE_PLAYER_MOUSELOOK_ON = true;
 				SLID_START = g_platformTime.frameStart();
-				ARX_INTERFACE_Combat_Mode(2);
+				ARX_INTERFACE_Combat_Mode(COMBAT_MODE_DRAW_WEAPON);
 			}
 		}
 	}
@@ -1362,7 +1362,7 @@ void ArxGame::managePlayerControls() {
 						TRUE_PLAYER_MOUSELOOK_ON = false;
 
 						if(player.Interface & INTER_COMBATMODE)
-							ARX_INTERFACE_Combat_Mode(0);			
+							ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);			
 					}
 				}
 			}
@@ -1370,13 +1370,13 @@ void ArxGame::managePlayerControls() {
 	}
 
 	if((player.Interface & INTER_COMBATMODE) && GInput->actionNowReleased(CONTROLS_CUST_FREELOOK)) {
-		ARX_INTERFACE_Combat_Mode(0);
+		ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
 	}
 
 	// Checks INVENTORY Key Status.
 	if(GInput->actionNowPressed(CONTROLS_CUST_INVENTORY)) {
 		if(player.Interface & INTER_COMBATMODE) {
-			ARX_INTERFACE_Combat_Mode(0);
+			ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
 		}
 
 		bInverseInventory=!bInverseInventory;
@@ -1406,7 +1406,7 @@ void ArxGame::managePlayerControls() {
 			COMBAT_MODE_ON_START_TIME = arxtime.now();
 		} else {
 			if(arxtime.now() - COMBAT_MODE_ON_START_TIME > ArxDurationMs(10)) {
-				ARX_INTERFACE_Combat_Mode(1);
+				ARX_INTERFACE_Combat_Mode(COMBAT_MODE_ON);
 			}
 		}
 	}

--- a/src/gui/Interface.cpp
+++ b/src/gui/Interface.cpp
@@ -856,7 +856,7 @@ static void GetInfosCombine() {
 // 1 to force Combat Mode On
 // 0 to force Combat Mode Off
 //-----------------------------------------------------------------------------
-void ARX_INTERFACE_Combat_Mode(ARX_INTERFACE_COMBAT_MODE i) {
+void ARX_INTERFACE_setCombatMode(ARX_INTERFACE_COMBAT_MODE i) {
 	arx_assert(entities.player());
 	arx_assert(arrowobj);
 	
@@ -1320,7 +1320,7 @@ void ArxGame::managePlayerControls() {
 
 		if(bGo) {
 			if(player.Interface & INTER_COMBATMODE) {
-				ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
+				ARX_INTERFACE_setCombatMode(COMBAT_MODE_OFF);
 				SPECIAL_DRAW_WEAPON=0;
 
 				if(config.input.mouseLookToggle)
@@ -1330,7 +1330,7 @@ void ArxGame::managePlayerControls() {
 				SPECIAL_DRAW_WEAPON=1;
 				TRUE_PLAYER_MOUSELOOK_ON = true;
 				SLID_START = g_platformTime.frameStart();
-				ARX_INTERFACE_Combat_Mode(COMBAT_MODE_DRAW_WEAPON);
+				ARX_INTERFACE_setCombatMode(COMBAT_MODE_DRAW_WEAPON);
 			}
 		}
 	}
@@ -1362,7 +1362,7 @@ void ArxGame::managePlayerControls() {
 						TRUE_PLAYER_MOUSELOOK_ON = false;
 
 						if(player.Interface & INTER_COMBATMODE)
-							ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);			
+							ARX_INTERFACE_setCombatMode(COMBAT_MODE_OFF);			
 					}
 				}
 			}
@@ -1370,13 +1370,13 @@ void ArxGame::managePlayerControls() {
 	}
 
 	if((player.Interface & INTER_COMBATMODE) && GInput->actionNowReleased(CONTROLS_CUST_FREELOOK)) {
-		ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
+		ARX_INTERFACE_setCombatMode(COMBAT_MODE_OFF);
 	}
 
 	// Checks INVENTORY Key Status.
 	if(GInput->actionNowPressed(CONTROLS_CUST_INVENTORY)) {
 		if(player.Interface & INTER_COMBATMODE) {
-			ARX_INTERFACE_Combat_Mode(COMBAT_MODE_OFF);
+			ARX_INTERFACE_setCombatMode(COMBAT_MODE_OFF);
 		}
 
 		bInverseInventory=!bInverseInventory;
@@ -1406,7 +1406,7 @@ void ArxGame::managePlayerControls() {
 			COMBAT_MODE_ON_START_TIME = arxtime.now();
 		} else {
 			if(arxtime.now() - COMBAT_MODE_ON_START_TIME > ArxDurationMs(10)) {
-				ARX_INTERFACE_Combat_Mode(COMBAT_MODE_ON);
+				ARX_INTERFACE_setCombatMode(COMBAT_MODE_ON);
 			}
 		}
 	}

--- a/src/gui/Interface.h
+++ b/src/gui/Interface.h
@@ -195,6 +195,12 @@ enum ARX_INTERFACE_CURSOR_MODE
 	CURSOR_COMBINEOFF
 };
 
+enum ARX_INTERFACE_COMBAT_MODE {
+	COMBAT_MODE_OFF,
+	COMBAT_MODE_ON,
+	COMBAT_MODE_DRAW_WEAPON
+};
+
 //-----------------------------------------------------------------------------
 extern INTERFACE_TC g_bookResouces;
 extern Vec2s MemoMouse;
@@ -217,7 +223,7 @@ extern gui::Note openNote;
 
 extern EntityHandle LastSelectedIONum;
 
-void ARX_INTERFACE_Combat_Mode(long i);
+void ARX_INTERFACE_Combat_Mode(ARX_INTERFACE_COMBAT_MODE i);
 
 long GetMainSpeakingIO();
 bool ARX_INTERFACE_MouseInBook();

--- a/src/gui/Interface.h
+++ b/src/gui/Interface.h
@@ -223,7 +223,7 @@ extern gui::Note openNote;
 
 extern EntityHandle LastSelectedIONum;
 
-void ARX_INTERFACE_Combat_Mode(ARX_INTERFACE_COMBAT_MODE i);
+void ARX_INTERFACE_setCombatMode(ARX_INTERFACE_COMBAT_MODE i);
 
 bool ARX_INTERFACE_MouseInBook();
 

--- a/src/gui/Interface.h
+++ b/src/gui/Interface.h
@@ -225,7 +225,6 @@ extern EntityHandle LastSelectedIONum;
 
 void ARX_INTERFACE_Combat_Mode(ARX_INTERFACE_COMBAT_MODE i);
 
-long GetMainSpeakingIO();
 bool ARX_INTERFACE_MouseInBook();
 
 void ARX_INTERFACE_Reset();

--- a/src/gui/MainMenu.cpp
+++ b/src/gui/MainMenu.cpp
@@ -998,6 +998,17 @@ public:
 			cb->iState = config.interface.hudScaleInteger ? 1 : 0;
 			addCenter(cb);
 		}
+
+		{
+			std::string szMenuText = getLocalised("system_menus_options_interface_scale_cursor_with_hud",
+												  "Scale cursor with HUD");
+			TextWidget * txt = new TextWidget(BUTTON_INVALID, hFontMenu, szMenuText, Vec2f(20, 0));
+			txt->SetCheckOff();
+			CheckboxWidget * cb = new CheckboxWidget(txt);
+			cb->stateChanged = boost::bind(&InterfaceOptionsMenuPage::onChangedScaleCursorWithHud, this, _1);
+			cb->iState = config.interface.scaleCursorWithHud ? 1 : 0;
+			addCenter(cb);
+		}
 		
 		{
 			PanelWidget * panel = new PanelWidget;
@@ -1054,6 +1065,10 @@ private:
 	void onChangedHudScaleInteger(int state) {
 		config.interface.hudScaleInteger = state ? true : false;
 		g_hudRoot.recalcScale();
+	}
+
+	void onChangedScaleCursorWithHud(int state) {
+		config.interface.scaleCursorWithHud = state ? true : false;
 	}
 	
 	void onChangedHudScaleFilter(int pos, const std::string & str) {


### PR DESCRIPTION
I left the attribute/skill point redistribution cursor as it is because it would look weird with the book being scaled by a different ratio at this point.