### PR TITLE
Fix persistent arrow trails

### DIFF
--- a/src/graphics/effects/Trail.cpp
+++ b/src/graphics/effects/Trail.cpp
@@ -33,7 +33,7 @@ Trail::Trail(long duration, Color4f startColor, Color4f endColor, float startSiz
 	segments = std::max(segments, size_t(4));
 	
 	m_timePerSegment = float(duration) / float(segments);
-	m_timeOfLastSegment = 0;
+	m_lastSegmentDuration = 0;
 	
 	m_positions.set_capacity(segments);
 	m_segments.reserve(segments);
@@ -60,13 +60,13 @@ void Trail::Update(float timeDelta) {
 	if(arxtime.is_paused())
 		return;
 	
-	m_timeOfLastSegment += timeDelta;
+	m_lastSegmentDuration += timeDelta;
 	
-	if(m_timeOfLastSegment < m_timePerSegment) {
+	if(m_lastSegmentDuration < m_timePerSegment) {
 		if(!m_positions.empty())
 			m_positions.pop_front();
 	} else {
-		m_timeOfLastSegment = 0;
+		m_lastSegmentDuration = 0;
 	}
 	
 	m_positions.push_front(m_nextPosition);

--- a/src/graphics/effects/Trail.h
+++ b/src/graphics/effects/Trail.h
@@ -49,7 +49,7 @@ private:
 	};
 
 	float m_timePerSegment;
-	float m_timeOfLastSegment;
+	float m_lastSegmentDuration;
 	std::vector<TrailSegment> m_segments;
 
 	Vec3f m_nextPosition;

--- a/src/physics/Projectile.cpp
+++ b/src/physics/Projectile.cpp
@@ -369,6 +369,7 @@ void ARX_THROWN_OBJECT_Manage(float time_offset)
 		BackgroundTileData * bkgData = getFastBackgroundData(projectile.position.x, projectile.position.z);
 
 		if(!bkgData || !bkgData->treat) {
+			ARX_THROWN_OBJECT_Kill(i); //projectile got outside of the world
 			continue;
 		}
 


### PR DESCRIPTION
Sometimes, especially at lower framerates, arrows would fly through solid geometry and leave visible trails that wouldn't go away. 
Now offending projectiles are killed right away (these wouldn't have any proper gameplay use anyway).