### PR TITLE
Replace casts with floor and clamp

### DIFF
--- a/src/scene/ChangeLevel.cpp
+++ b/src/scene/ChangeLevel.cpp
@@ -1746,8 +1746,8 @@ static long ARX_CHANGELEVEL_Pop_Player() {
 	player.m_misc.resistMagic = glm::floor(asp->resist_magic);
 	player.m_misc.resistPoison = glm::floor(asp->resist_poison);
 	
-	player.Attribute_Redistribute = checked_range_cast<unsigned char>(asp->Attribute_Redistribute);
-	player.Skill_Redistribute = checked_range_cast<unsigned char>(asp->Skill_Redistribute);
+	player.Attribute_Redistribute = glm::clamp(asp->Attribute_Redistribute, s16(0), s16(std::numeric_limits<unsigned char>::max()));
+	player.Skill_Redistribute = glm::clamp(asp->Skill_Redistribute, s16(0), s16(std::numeric_limits<unsigned char>::max()));
 	
 	player.rune_flags = RuneFlags::load(asp->rune_flags); // TODO save/load flags
 	player.size = asp->size.toVec3();

--- a/src/scene/ChangeLevel.cpp
+++ b/src/scene/ChangeLevel.cpp
@@ -1743,8 +1743,8 @@ static long ARX_CHANGELEVEL_Pop_Player() {
 	WILL_RESTORE_PLAYER_POSITION = asp->pos.toVec3();
 	WILL_RESTORE_PLAYER_POSITION_FLAG = true;
 	
-	player.m_misc.resistMagic = checked_range_cast<unsigned char>(asp->resist_magic);
-	player.m_misc.resistPoison = checked_range_cast<unsigned char>(asp->resist_poison);
+	player.m_misc.resistMagic = glm::floor(asp->resist_magic);
+	player.m_misc.resistPoison = glm::floor(asp->resist_poison);
 	
 	player.Attribute_Redistribute = checked_range_cast<unsigned char>(asp->Attribute_Redistribute);
 	player.Skill_Redistribute = checked_range_cast<unsigned char>(asp->Skill_Redistribute);


### PR DESCRIPTION
Prevent crashes due to unhandled exceptions if values are unusually high. While we can't possibly handle every consequence of cheating, the game shouldn't crash if these values are slightly higher.

Also fixes issue #1072.