### PR TITLE
Damage: Fix DoSphericalDamage doing decreased damage

### DIFF
--- a/src/game/Damage.cpp
+++ b/src/game/Damage.cpp
@@ -1312,7 +1312,7 @@ void DoSphericDamage(const Sphere & sphere, float dmg, DamageArea flags, DamageT
 			}
 		}
 		
-		float ratio = glm::max(count, count2) / float(ioo->obj->vertexlist.size()) / 2.f;
+		float ratio = glm::max(count, count2) / (float(ioo->obj->vertexlist.size()) / 2.f);
 		
 		if(ratio > 2.f)
 			ratio = 2.f;


### PR DESCRIPTION
Spherical damage done to NPCs was incorrectly modified by commit dd3a57f