### PR TITLE
CMake: Fix build without Git dir (from tarball)

### DIFF
--- a/cmake/VersionString.cmake
+++ b/cmake/VersionString.cmake
@@ -82,6 +82,8 @@ function(version_file SRC DST VERSION_SOURCES GIT_DIR)
 		if(EXISTS "${abs_git_dir}/logs/HEAD")
 			list(APPEND dependencies "${abs_git_dir}/logs/HEAD")
 		endif()
+	else()
+		set(abs_git_dir "")
 	endif()
 	
 	add_custom_command(


### PR DESCRIPTION
I had a build issue with the current master branch on Mageia's buildsystem, from a static tarball and without Git installed:
```
make[2]: Entering directory '/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/build'
/usr/bin/cmake -DINPUT=/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/src/core/Version.cpp.in -DOUTPUT=/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/build/core/Version.cpp "-DVERSION_SOURCES=VERSION;/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/VERSION;AUTHORS;/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/AUTHORS;COPYING;/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/COPYING" -DGIT_DIR=/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/.git -DGIT_COMMAND= -P /home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/cmake/VersionScript.cmake
make[2]: Leaving directory '/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/build'
make[2]: *** Deleting file 'core/Version.cpp'
make[2]: Entering directory '/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/build'
/usr/bin/cmake -DINPUT=/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/src/core/Version.cpp.in -DOUTPUT=/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/build/core/Version.cpp "-DVERSION_SOURCES=VERSION;/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/VERSION;AUTHORS;/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/AUTHORS;COPYING;/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/COPYING" -DGIT_DIR=/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/.git -DGIT_COMMAND= -P /home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/cmake/VersionScript.cmake
CMake Error at /home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/cmake/VersionScript.cmake:89 (configure_file):
  configure_file Problem configuring file


make[2]: *** [CMakeFiles/arx.dir/build.make:68: core/Version.cpp] Error 1
make[2]: Leaving directory '/home/iurt/rpmbuild/BUILD/ArxLibertatis-5f41c29608b74607244f532ee7e19c54e4cd93b3/build'
make[1]: *** [CMakeFiles/Makefile2:209: CMakeFiles/arx.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

I couldn't reproduce it locally, but this patch seems to have fixed it (or maybe it was a transient issue and I was just lucky the second time with that patch).