### PR TITLE
CMake: Detect the --without-gui inkscape option before using it

### DIFF
--- a/cmake/FindInkscape.cmake
+++ b/cmake/FindInkscape.cmake
@@ -5,6 +5,7 @@
 # Inkscape_FOUND
 # Inkscape_EXECUTABLE   Where to find Inkscape
 # Inkscape_EXPORT       Option to specify the destination file
+# Inkscape_GUI          Option to disable the GUI if needed
 
 find_program(
 	Inkscape_EXECUTABLE
@@ -12,8 +13,13 @@ find_program(
 	DOC "Inkscape command-line SVG rasterizer"
 )
 
+execute_process(COMMAND ${Inkscape_EXECUTABLE} "--help" OUTPUT_VARIABLE _Inkscape_HELP ERROR_QUIET)
+
+if(_Inkscape_HELP MATCHES "--without-gui")
+	set(Inkscape_GUI "--without-gui" CACHE STRING "Inkscape option to disable the GUI if needed")
+endif()
+
 if(NOT DEFINED Inkscape_EXPORT)
-	execute_process(COMMAND ${Inkscape_EXECUTABLE} "--help" OUTPUT_VARIABLE _Inkscape_HELP ERROR_QUIET)
 	foreach(option IN ITEMS "--export-file" "--export-filename" "--export-png")
 		if(_Inkscape_HELP MATCHES "${option}=")
 			set(Inkscape_EXPORT "${option}" CACHE STRING "Inkscape option to specify the export filename")

--- a/cmake/Icons.cmake
+++ b/cmake/Icons.cmake
@@ -812,7 +812,7 @@ function(_add_icon_size var size)
 		add_custom_command(
 			OUTPUT "${source_file}"
 			COMMAND "${CMAKE_COMMAND}" -E make_directory "${ICON_BINARY_DIR}"
-			COMMAND "${Inkscape_EXECUTABLE}" "--without-gui" ${Inkscape_OPTIONS}
+			COMMAND "${Inkscape_EXECUTABLE}" ${Inkscape_GUI} ${Inkscape_OPTIONS}
 				"${source_svg}" "--export-width=${render_w}" "--export-height=${render_h}"
 				"${Inkscape_EXPORT}=${source_file}"
 			MAIN_DEPENDENCY "${source_svg}"


### PR DESCRIPTION
The `--without-gui`/`-z` option is no longer defined in Inkscape 1.0, and it causes the build to fail due to an unknown argument.  This only uses it if it is defined in Inkscape's help text.

Fedora 32 updated to Inkscape 1.0, and the build fails due to the unknown argument.  I ran this change on Fedora 32 and Fedora 30 (which still uses an older Inkscape), and it works for both.  I'm not sure if the option is actually required for older versions since it seems to work on Fedora 30 without it, but I ran it on a headless build system.  Maybe the option could be dropped and `DISPLAY` unset to make it unconditional.