### PR TITLE
CMakeLists: fix linker errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1735,6 +1735,7 @@ if(BUILD_TOOLS)
 		${PLATFORM_CONSOLE_SOURCES}
 		${IO_RESOURCE_SOURCES}
 		${UTIL_CMDLINE_SOURCES}
+		${MATH_SOURCES}
 		src/core/Localisation.cpp
 		src/io/SaveBlock.cpp
 		src/io/IniReader.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_source_flags("${arxtest_TESTCASES}" "${enable_rtti} ${disable_libstdcxx_debu
 set(arxtest_SOURCES
 	
 	${BASE_SOURCES}
+	${MATH_SOURCES}
 	
 	src/game/Camera.cpp
 	src/graphics/Math.cpp


### PR DESCRIPTION
Fixes undefined reference for "Random::rng". 

Although it does build on GCC and MSVC, it doesn't on LCC (Elbrus 2000 compiler).