### PR TITLE
Stop casting animation from playing on failed cast

### DIFF
--- a/src/game/Spells.cpp
+++ b/src/game/Spells.cpp
@@ -547,8 +547,12 @@ void ARX_SPELLS_ManageMagic() {
 		CheatDetectionReset();
 		
 		if(CurrSpellSymbol != 0) {
-			if(!ARX_SPELLS_AnalyseSPELL()) {
-				if(io->anims[ANIM_CAST]) {
+			if(!ARX_SPELLS_AnalyseSPELL()) { // CHANGE: If the cast fails, play CAST_END
+				if(io->anims[ANIM_CAST_END]) {
+					changeAnimation(io, 1, io->anims[ANIM_CAST_END]);
+				}
+			} else {
+				if (io->anims[ANIM_CAST]) { // CHANGE: Otherwise play CAST
 					changeAnimation(io, 1, io->anims[ANIM_CAST]);
 				}
 			}


### PR DESCRIPTION
Whenever a cast fails, either low mana or low skill, the normal casting animation is played.
This adds a check to play the cast end animation in those cases.
this fix is made by YetiWizard#0170 im just doing the git stuff for him