### PR TITLE
Exposed mana properties of the player as script variables

### DIFF
--- a/src/script/Script.cpp
+++ b/src/script/Script.cpp
@@ -1125,7 +1125,7 @@ ValueType getSystemVar(const script::Context & context, std::string_view name,
 			}
 
 			if(boost::starts_with(name, "^player_maxmana")) {
-				*fcontent = player.manaPool.max;
+				*fcontent = player.Full_maxmana;
 				return TYPE_FLOAT;
 			}
 			

--- a/src/script/Script.cpp
+++ b/src/script/Script.cpp
@@ -1083,6 +1083,11 @@ ValueType getSystemVar(const script::Context & context, std::string_view name,
 				*fcontent = player.Full_life; // TODO why not player.life like everywhere else?
 				return TYPE_FLOAT;
 			}
+
+			if(boost::starts_with(name, "^player_mana")) {
+				*fcontent = player.manaPool.current;
+				return TYPE_FLOAT;
+			}
 			
 			if(boost::starts_with(name, "^poisoned")) {
 				*fcontent = 0;
@@ -1116,6 +1121,11 @@ ValueType getSystemVar(const script::Context & context, std::string_view name,
 			
 			if(boost::starts_with(name, "^player_maxlife")) {
 				*fcontent = player.Full_maxlife;
+				return TYPE_FLOAT;
+			}
+
+			if(boost::starts_with(name, "^player_maxmana")) {
+				*fcontent = player.manaPool.max;
 				return TYPE_FLOAT;
 			}
 			


### PR DESCRIPTION
Similarly to `^player_life` and `^player_maxlife` with this addon we'll have `^player_mana` and `^player_maxmana`

(will be used in my "the backrooms" custom Arx map: https://github.com/meszaros-lajos-gyorgy/arx-level-generator/blob/master/src/projects/the-backrooms/index.js#L595)