### PR TITLE
extend localisation with possibility for having mod specific textfiles

### DIFF
--- a/src/core/Localisation.cpp
+++ b/src/core/Localisation.cpp
@@ -289,10 +289,12 @@ Languages getAvailableTextLanguages() {
 			// Missing language name.
 			continue;
 		}
-		
+
+		const std::string_view modname = name.substr(prefix.length(), name.find_last_of("_") - (prefix.length() - 1));
+
 		// Extract the language name.
-		size_t length = name.length() - prefix.length() - suffix.length();
-		std::string_view id = name.substr(prefix.length(), length);
+		size_t length = name.length() - prefix.length() - modname.length() - suffix.length();
+		std::string_view id = name.substr(prefix.length() + modname.length(), length);
 		
 		if(id.find_first_not_of("abcdefghijklmnopqrstuvwxyz_") != std::string_view::npos) {
 			LogWarning << "Ignoring localisation/" << name;

--- a/src/core/Localisation.h
+++ b/src/core/Localisation.h
@@ -23,12 +23,13 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <vector>
 
 struct Language {
 	
 	std::string name;
 	std::string locale;
-	
+	std::vector<std::string> mods;
 };
 
 typedef std::map<std::string, Language> Languages;


### PR DESCRIPTION
The game looks for language files in the following format `utext_<language>.ini` and if a modder wants to extend the language files then he/she has to include all the strings from the original file.
This modification allows modders to add files, like `utext_mymod_english.ini` or `utext_my_custom_mod_english.ini`.

The game will load the language files in the following order: `utext_english.ini` -> `utext_mod1_english.ini` -> `utext_mod2_english.ini`

Remaining todos:

 - update `initLocalisation` to glob all mod files after loading the main language file.