### PR TITLE
Add system variables to get the real life year, month and day values as an integer

### DIFF
--- a/src/script/Script.cpp
+++ b/src/script/Script.cpp
@@ -52,6 +52,7 @@ ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
 #include <exception>
 #include <limits>
 #include <sstream>
+#include <chrono>
 
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -691,6 +692,30 @@ ValueType getSystemVar(const script::Context & context, std::string_view name,
 					}
 					return TYPE_FLOAT;
 				}
+			}
+
+			if(name == "^realtime_year") {
+				std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+				time_t tt = std::chrono::system_clock::to_time_t(now);
+				tm local_tm = *localtime(&tt);
+				*lcontent = static_cast<long>(local_tm.tm_year + 1900);
+				return TYPE_LONG;
+			}
+
+			if(name == "^realtime_month") {
+				std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+				time_t tt = std::chrono::system_clock::to_time_t(now);
+				tm local_tm = *localtime(&tt);
+				*lcontent = static_cast<long>(local_tm.tm_mon + 1);
+				return TYPE_LONG;
+			}
+
+			if(name == "^realtime_day") {
+				std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+				time_t tt = std::chrono::system_clock::to_time_t(now);
+				tm local_tm = *localtime(&tt);
+				*lcontent = static_cast<long>(local_tm.tm_mday);
+				return TYPE_LONG;
 			}
 			
 			if(boost::starts_with(name, "^repairprice_")) {


### PR DESCRIPTION
Adds the following 3 system variables to the game:

`^realtime_year` - the current year in real life
`^realtime_month` - the current month in real life
`^realtime_day` - the current day in real life

The idea: replace apples with pumpkins and apple pies with pumpkin pies on halloween or adding any other holiday events based on date values.

```c
// provisions/food_apple/food_apple.asl

ON INIT {
  // ...
  IF (^#realtime_month == 10) {
    IF (^#realtime_day == 31) {
      SETNAME "pumpkin"
      SETSCALE 300
      TWEAK SKIN "item_fruits" "item_pumpkin"
    }
  }
  ACCEPT
}
```
