### PR TITLE
Independent earthquakes

### DIFF
--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -30,7 +30,6 @@ struct QUAKE_FX_STRUCT {
 	float frequency;
 	GameInstant start;
 	GameDuration duration;
-	bool sound;
 };
 
 QUAKE_FX_STRUCT QuakeFx;
@@ -43,7 +42,6 @@ void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound
 		QuakeFx.duration += duration;
 		QuakeFx.frequency += period;
 		QuakeFx.frequency *= .5f;
-		QuakeFx.sound = QuakeFx.sound || sound;
 	} else {
 		QuakeFx.intensity = intensity;
 
@@ -51,7 +49,6 @@ void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound
 
 		QuakeFx.duration = duration;
 		QuakeFx.frequency = period;
-		QuakeFx.sound = sound;
 	}
 
 	if(!sound) {

--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -25,6 +25,8 @@
 #include "math/RandomVector.h"
 #include "scene/GameSound.h"
 
+#define QUAKE_ADJUST 0.4f //adjustment to make quakes look like the original in strength
+
 struct QUAKE_FX_STRUCT {
 	float intensity;
 	float frequency;
@@ -82,17 +84,12 @@ void ManageQuakeFX(Camera * cam) {
 		
 		float itmod = 1.f - (elapsed / QuakeFx.duration);
 		
-		float periodicity = 0;
-		if(QuakeFx.frequency > 0.f) {
-			periodicity = timeWaveSin(g_gameTime.now(), 200ms / QuakeFx.frequency * glm::pi<float>());
-		}
-		
-		float truepower = periodicity * QuakeFx.intensity * itmod * 0.01f;
+		float truepower = QuakeFx.intensity * itmod * 0.01f * QUAKE_ADJUST;
 		float halfpower = truepower * .5f;
 		
 		cam->m_pos += arx::randomVec(-halfpower, halfpower);
-		cam->angle.setPitch(cam->angle.getPitch() + Random::getf() * truepower - halfpower);
-		cam->angle.setYaw(cam->angle.getYaw() + Random::getf() * truepower - halfpower);
-		cam->angle.setRoll(cam->angle.getRoll() + Random::getf() * truepower - halfpower);
+		cam->angle.setPitch(cam->angle.getPitch() + Random::getf(-1.f, 1.f) * truepower - halfpower);
+		cam->angle.setYaw(cam->angle.getYaw() + Random::getf(-1.f, 1.f) * truepower - halfpower);
+		cam->angle.setRoll(cam->angle.getRoll() + Random::getf(-1.f, 1.f) * truepower - halfpower);
 	}
 }

--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -72,8 +72,7 @@ void ManageQuakeFX(Camera * cam) {
 		GameDuration elapsed = g_gameTime.now() - QuakeFx.start;
 
 		if(elapsed >= QuakeFx.duration) {
-			QuakeFx.intensity = 0.f;
-			QuakeFx.active = false;
+			RemoveQuakeFX();
 			return;
 		}
 		

--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -27,7 +27,7 @@
 
 struct QUAKE_FX_STRUCT {
 	float intensity;
-	float frequency;
+	float period;
 	GameInstant start;
 	GameDuration duration;
 	bool active;
@@ -46,13 +46,13 @@ void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound
 	if(QuakeFx.active) {
 		QuakeFx.intensity += intensity;
 		QuakeFx.duration += duration;
-		QuakeFx.frequency += period;
-		QuakeFx.frequency *= .5f;
+		QuakeFx.period += period;
+		QuakeFx.period *= .5f;
 	} else {
 		QuakeFx.intensity = intensity;
 		QuakeFx.start = g_gameTime.now();
 		QuakeFx.duration = duration;
-		QuakeFx.frequency = period;
+		QuakeFx.period = period;
 		QuakeFx.active = true;
 		QuakeFx.lastChange = 0;
 	}
@@ -86,8 +86,8 @@ void ManageQuakeFX(Camera * cam) {
 		
 		// adjustment of frequency to linearity because the actual value is nonlinear, using a formula of x/(x + k)
 		// values chosen so a scripted earthquake with a frequency of 10 changes direction every ~10ms
-		float multiplier = 2 * (1.f - QuakeFx.frequency / (QuakeFx.frequency + 10.0f));
-		float updateInterval = QuakeFx.frequency * multiplier;
+		float multiplier = 2 * (1.f - QuakeFx.period / (QuakeFx.period + 10.0f));
+		float updateInterval = QuakeFx.period * multiplier;
 		
 		float itmod = 1.f - (elapsed / QuakeFx.duration);
 		

--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -69,9 +69,9 @@ void RemoveQuakeFX() {
 
 void ManageQuakeFX(Camera * cam) {
 	if(QuakeFx.intensity > 0.f) {
-		GameDuration tim = g_gameTime.now() - QuakeFx.start;
+		GameDuration elapsed = g_gameTime.now() - QuakeFx.start;
 
-		if(tim >= QuakeFx.duration) {
+		if(elapsed >= QuakeFx.duration) {
 			QuakeFx.intensity = 0.f;
 			return;
 		}
@@ -80,7 +80,7 @@ void ManageQuakeFX(Camera * cam) {
 			return;
 		}
 		
-		float itmod = 1.f - (tim / QuakeFx.duration);
+		float itmod = 1.f - (elapsed / QuakeFx.duration);
 		
 		float periodicity = 0;
 		if(QuakeFx.frequency > 0.f) {

--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -32,7 +32,7 @@ struct QUAKE_FX_STRUCT {
 	GameDuration duration;
 };
 
-QUAKE_FX_STRUCT QuakeFx;
+QUAKE_FX_STRUCT QuakeFx = {0.f, 0.f, GameInstant(), GameDuration()};
 
 void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound) {
 

--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -45,15 +45,12 @@ void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound
 
 	if(QuakeFx.active) {
 		QuakeFx.intensity += intensity;
-
 		QuakeFx.duration += duration;
 		QuakeFx.frequency += period;
 		QuakeFx.frequency *= .5f;
 	} else {
 		QuakeFx.intensity = intensity;
-
 		QuakeFx.start = g_gameTime.now();
-
 		QuakeFx.duration = duration;
 		QuakeFx.frequency = period;
 		QuakeFx.active = true;

--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -40,6 +40,9 @@ QUAKE_FX_STRUCT QuakeFx = {0.f, 0.f, GameInstant(), GameDuration(), false, Angle
 
 void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound) {
 
+	if(duration <= 0 && period <= 0)
+		return;
+
 	if(QuakeFx.active) {
 		QuakeFx.intensity += intensity;
 

--- a/src/game/effect/Quake.cpp
+++ b/src/game/effect/Quake.cpp
@@ -30,13 +30,14 @@ struct QUAKE_FX_STRUCT {
 	float frequency;
 	GameInstant start;
 	GameDuration duration;
+	bool active;
 };
 
-QUAKE_FX_STRUCT QuakeFx = {0.f, 0.f, GameInstant(), GameDuration()};
+QUAKE_FX_STRUCT QuakeFx = {0.f, 0.f, GameInstant(), GameDuration(), false};
 
 void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound) {
 
-	if(QuakeFx.intensity > 0.f) {
+	if(QuakeFx.active) {
 		QuakeFx.intensity += intensity;
 
 		QuakeFx.duration += duration;
@@ -49,6 +50,7 @@ void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound
 
 		QuakeFx.duration = duration;
 		QuakeFx.frequency = period;
+		QuakeFx.active = true;
 	}
 
 	if(!sound) {
@@ -62,14 +64,16 @@ void AddQuakeFX(float intensity, GameDuration duration, float period, bool sound
 
 void RemoveQuakeFX() {
 	QuakeFx.intensity = 0.f;
+	QuakeFx.active = false;
 }
 
 void ManageQuakeFX(Camera * cam) {
-	if(QuakeFx.intensity > 0.f) {
+	if(QuakeFx.active) {
 		GameDuration elapsed = g_gameTime.now() - QuakeFx.start;
 
 		if(elapsed >= QuakeFx.duration) {
 			QuakeFx.intensity = 0.f;
+			QuakeFx.active = false;
 			return;
 		}
 		


### PR DESCRIPTION
Attempted to replace the calculation with random values (looks about the same) because the old algorithm didn't really work when trying to update only once in a few milliseconds. The update period for intensity of 10 (scripted cobweb earthquake) is at 10ms but new values are chosen at the next function call so it looks fairly close even at 30fps with frame time of ~33ms.

Included are three save files that contain examples of quakes:
Scripted cobweb quake - AFAIK strongest in the game, short period
Giant worm - another scripted quake when the worm moves, weaker, longer period
Ylside bunker - one of the strongest hits from NPCs, long period

Let me know what you think of the look and feel.

[saves.zip](https://github.com/arx/ArxLibertatis/files/11602605/saves.zip)