### PR TITLE
noclip command

### DIFF
--- a/src/core/ArxGame.cpp
+++ b/src/core/ArxGame.cpp
@@ -553,6 +553,7 @@ private:
 GameFlow::Transition GameFlow::s_currentTransition = GameFlow::FirstLogo;
 
 static AreaId g_areaToLoad = AreaId(10);
+static bool g_initialPlayerCollision = true;
 
 static void skipLogo() {
 	if(GameFlow::getTransition() != GameFlow::LoadingScreen) {
@@ -560,6 +561,11 @@ static void skipLogo() {
 	}
 }
 ARX_PROGRAM_OPTION("skiplogo", "", "Skip logos at startup", &skipLogo)
+
+static void startWithNoclip() {
+	g_initialPlayerCollision = false;
+}
+ARX_PROGRAM_OPTION("noclip", "", "Start the game with noclipping enabled", &startWithNoclip)
 
 static void loadLevel(u32 level) {
 	g_areaToLoad = AreaId(level);
@@ -658,6 +664,10 @@ static bool HandleGameFlowTransitions() {
 		LoadLevelScreen(g_areaToLoad);
 		
 		DanaeLoadLevel(g_areaToLoad);
+		
+		USE_PLAYERCOLLISIONS = g_initialPlayerCollision;
+		g_initialPlayerCollision = true;
+		
 		GameFlow::setTransition(GameFlow::InGame);
 		return false;
 	}

--- a/src/script/ScriptUtils.cpp
+++ b/src/script/ScriptUtils.cpp
@@ -125,11 +125,11 @@ std::string Context::getCommand(bool skipNewlines) {
 	return word;
 }
 
-std::string Context::getWord() {
+std::string Context::getWord(bool warnNewlines) {
 	
 	std::string_view esdat = m_script->data;
 	
-	skipWhitespace(false, true);
+	skipWhitespace(false, warnNewlines);
 	
 	if(m_pos >= esdat.size()) {
 		return std::string();
@@ -201,6 +201,16 @@ std::string Context::getWord() {
 	}
 	
 	return word;
+}
+
+std::string Context::peekWord() {
+	
+	size_t old_m_pos = m_pos;
+	std::string word = getWord(false);
+	m_pos = old_m_pos;
+	
+	return word;
+	
 }
 
 void Context::skipWord() {

--- a/src/script/ScriptUtils.h
+++ b/src/script/ScriptUtils.h
@@ -98,7 +98,8 @@ public:
 	
 	std::string getStringVar(std::string_view name) const;
 	std::string getFlags();
-	std::string getWord();
+	std::string getWord(bool warnNewlines = true);
+	std::string peekWord();
 	void skipWord();
 	
 	std::string getCommand(bool skipNewlines = true);

--- a/src/script/ScriptedPlayer.cpp
+++ b/src/script/ScriptedPlayer.cpp
@@ -666,6 +666,29 @@ public:
 	
 };
 
+class NoclipCommand : public Command {
+	
+public:
+	
+	NoclipCommand() : Command("noclip") { }
+	
+	Result execute(Context & context) override {
+		
+		bool enable = context.getBool();
+		
+		DebugScript(' ' << enable);
+		
+		if(enable) {
+			USE_PLAYERCOLLISIONS = false;
+		} else {
+			USE_PLAYERCOLLISIONS = true;
+		}
+		
+		return Success;
+	}
+	
+};
+
 } // anonymous namespace
 
 void setupScriptedPlayer() {
@@ -687,6 +710,7 @@ void setupScriptedPlayer() {
 	ScriptEvent::registerCommand(std::make_unique<PoisonCommand>());
 	ScriptEvent::registerCommand(std::make_unique<PlayerManaDrainCommand>());
 	ScriptEvent::registerCommand(std::make_unique<InvulnerabilityCommand>());
+	ScriptEvent::registerCommand(std::make_unique<NoclipCommand>());
 	
 }
 

--- a/src/script/ScriptedPlayer.cpp
+++ b/src/script/ScriptedPlayer.cpp
@@ -673,15 +673,18 @@ public:
 	NoclipCommand() : Command("noclip") { }
 	
 	Result execute(Context & context) override {
+		std::string param = context.peekWord();
 		
-		bool enable = context.getBool();
-		
-		DebugScript(' ' << enable);
-		
-		if(enable) {
-			USE_PLAYERCOLLISIONS = false;
-		} else {
-			USE_PLAYERCOLLISIONS = true;
+		if(param == "on" || param == "yes" || param == "off" || param == "no") {
+			bool enable = context.getBool();
+			
+			DebugScript(' ' << enable);
+			
+			USE_PLAYERCOLLISIONS = !enable;
+		} else if(param == "") {
+			DebugScript(' ');
+			
+			USE_PLAYERCOLLISIONS = !USE_PLAYERCOLLISIONS;
 		}
 		
 		return Success;


### PR DESCRIPTION
This pull request aims to add the following features:

1. add `noclip` command, which toggles player collision every time when called
2. add `noclip on/off/yes/no` command, which lets the player set the player collision
3. add `--noclip` command line argument so that `./arx --loadlevel 0 --noclip` loads a specific level with player collision disabled

I know that adding this command breaks all conventions so far by making cheating 10x easier, but it would be great help for mapmakers, like myself, who generate mesh from code and have to load the game after each little change. I lost count of how many hours I've wasted drawing the stair symbols in a loop of adjust coordinates -> run arx.exe --loadlevel 1 -> check one little thing with noclipping -> exit the game and back to the IDE.