### PR TITLE
OpenALSource: Fix incorrect condition

### DIFF
--- a/src/audio/openal/OpenALSource.cpp
+++ b/src/audio/openal/OpenALSource.cpp
@@ -761,7 +761,7 @@ aalError OpenALSource::updateBuffers() {
 }
 
 bool OpenALSource::markAsLoaded() {
-	if(m_loadCount == unsigned(-1)) {
+	if(m_loadCount != unsigned(-1)) {
 		m_loadCount--;
 	}
 	return (m_loadCount != 0);


### PR DESCRIPTION
The condition that was introduced in the following commit needs to be inverted: https://github.com/arx/ArxLibertatis/commit/955181fbeb52124200c586fc45e9407d73108921