### PR TITLE
Add support for spellcast command's -x flag for all spells

### DIFF
--- a/src/game/magic/spells/SpellsLvl01.cpp
+++ b/src/game/magic/spells/SpellsLvl01.cpp
@@ -64,20 +64,24 @@ void MagicSightSpell::Launch() {
 	
 	if(m_caster == EntityHandle_Player) {
 		player.m_improve = true;
-		m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_VISION_LOOP, &m_caster_pos, 1.f);
+		if(emitsSound) {
+			m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_VISION_LOOP, &m_caster_pos, 1.f);
+		}
 	}
 }
 
 void MagicSightSpell::End() {
 	
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
 	if(m_caster == EntityHandle_Player) {
 		player.m_improve = false;
 	}
 	
-	ARX_SOUND_Stop(m_snd_loop);
-	m_snd_loop = audio::SourcedSample();
-	
-	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	if(emitsSound) {
+		ARX_SOUND_Stop(m_snd_loop);
+		m_snd_loop = audio::SourcedSample();
+	}
 	
 	Entity * caster = entities.get(m_caster);
 	if(caster && emitsSound) {
@@ -231,11 +235,13 @@ void MagicMissileSpell::Launch() {
 		missile.SetDuration(lTime);
 	}
 	
-	if(!(m_flags & SPELLCAST_FLAG_NOSOUND)) {
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_MM_CREATE, &startPos);
 		ARX_SOUND_PlaySFX(g_snd.SPELL_MM_LAUNCH, &startPos);
+		snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_MM_LOOP, &startPos, 1.f);
 	}
-	snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_MM_LOOP, &startPos, 1.f);
 	
 	m_duration = lMax + 1s;
 }
@@ -248,8 +254,12 @@ void MagicMissileSpell::End() {
 	
 	m_missiles.clear();
 	
-	ARX_SOUND_Stop(snd_loop);
-	snd_loop = audio::SourcedSample();
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_Stop(snd_loop);
+		snd_loop = audio::SourcedSample();
+	}
 }
 
 void MagicMissileSpell::Update() {

--- a/src/game/magic/spells/SpellsLvl01.cpp
+++ b/src/game/magic/spells/SpellsLvl01.cpp
@@ -93,7 +93,11 @@ void MagicSightSpell::Update() {
 	
 	if(m_caster == EntityHandle_Player) {
 		Vec3f pos = ARX_PLAYER_FrontPos();
-		ARX_SOUND_RefreshPosition(m_snd_loop, pos);
+		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+		
+		if(emitsSound) {
+			ARX_SOUND_RefreshPosition(m_snd_loop, pos);
+		}
 	}
 }
 
@@ -309,7 +313,10 @@ void MagicMissileSpell::Update() {
 	}
 	
 	averageMissilePos /= float(m_missiles.size());
-	ARX_SOUND_RefreshPosition(snd_loop, averageMissilePos);
+	
+	if(emitsSound) {
+		ARX_SOUND_RefreshPosition(snd_loop, averageMissilePos);
+	}
 	
 	arx_assert(m_lights.size() == m_missiles.size());
 	
@@ -543,7 +550,11 @@ void DouseSpell::Update() {
 
 void ActivatePortalSpell::Launch() {
 	
-	ARX_SOUND_PlayInterface(g_snd.SPELL_ACTIVATE_PORTAL);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlayInterface(g_snd.SPELL_ACTIVATE_PORTAL);
+	}
 	
 	m_duration = 20ms;
 	m_hasDuration = true;

--- a/src/game/magic/spells/SpellsLvl02.cpp
+++ b/src/game/magic/spells/SpellsLvl02.cpp
@@ -181,7 +181,11 @@ void DetectTrapSpell::Update() {
 	
 	if(m_caster == EntityHandle_Player) {
 		Vec3f pos = ARX_PLAYER_FrontPos();
-		ARX_SOUND_RefreshPosition(m_snd_loop, pos);
+		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+		
+		if(emitsSound) {
+			ARX_SOUND_RefreshPosition(m_snd_loop, pos);
+		}
 	}
 }
 
@@ -253,7 +257,11 @@ void ArmorSpell::Update() {
 		io->halo.radius = 45.f;
 	}
 	
-	ARX_SOUND_RefreshPosition(m_snd_loop, entities[m_target]->pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_RefreshPosition(m_snd_loop, entities[m_target]->pos);
+	}
 }
 
 Vec3f ArmorSpell::getPosition() const {
@@ -337,7 +345,11 @@ void LowerArmorSpell::Update() {
 		}
 	}
 	
-	ARX_SOUND_RefreshPosition(m_snd_loop, entities[m_target]->pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_RefreshPosition(m_snd_loop, entities[m_target]->pos);
+	}
 }
 
 Vec3f LowerArmorSpell::getPosition() const {
@@ -414,5 +426,10 @@ void HarmSpell::Update() {
 		casterPos = entities[m_caster]->pos;
 	}
 	Vec3f cabalPos = m_cabal.update(casterPos);
-	ARX_SOUND_RefreshPosition(m_snd_loop, cabalPos);
+	
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_RefreshPosition(m_snd_loop, cabalPos);
+	}
 }

--- a/src/game/magic/spells/SpellsLvl02.cpp
+++ b/src/game/magic/spells/SpellsLvl02.cpp
@@ -47,7 +47,9 @@ bool HealSpell::CanLaunch() {
 
 void HealSpell::Launch() {
 	
-	if(!(m_flags & SPELLCAST_FLAG_NOSOUND)) {
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_HEALING, &m_caster_pos);
 	}
 	
@@ -189,7 +191,9 @@ void ArmorSpell::Launch()
 		m_target = m_caster;
 	}
 	
-	if(!(m_flags & SPELLCAST_FLAG_NOSOUND)) {
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_ARMOR_START, &entities[m_target]->pos);
 	}
 	
@@ -222,7 +226,11 @@ void ArmorSpell::End() {
 	
 	Entity * target = entities.get(m_target);
 	if(target) {
-		ARX_SOUND_PlaySFX(g_snd.SPELL_ARMOR_END, &target->pos);
+		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+		
+		if(emitsSound) {
+			ARX_SOUND_PlaySFX(g_snd.SPELL_ARMOR_END, &target->pos);
+		}
 		ARX_HALO_SetToNative(target);
 	}
 	
@@ -258,7 +266,9 @@ void LowerArmorSpell::Launch() {
 	spells.endByCaster(m_caster, SPELL_FIRE_PROTECTION);
 	spells.endByCaster(m_caster, SPELL_COLD_PROTECTION);
 	
-	if(!(m_flags & SPELLCAST_FLAG_NOSOUND)) {
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_LOWER_ARMOR, &entities[m_target]->pos);
 	}
 	
@@ -290,7 +300,11 @@ void LowerArmorSpell::Launch() {
 
 void LowerArmorSpell::End() {
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_LOWER_ARMOR_END);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_LOWER_ARMOR_END);
+	}
 	
 	if(m_haloCreated) {
 		Entity * io = entities.get(m_target);
@@ -325,7 +339,9 @@ Vec3f LowerArmorSpell::getPosition() const {
 
 void HarmSpell::Launch() {
 	
-	if(!(m_flags & SPELLCAST_FLAG_NOSOUND)) {
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_HARM, &m_caster_pos);
 	}
 	

--- a/src/game/magic/spells/SpellsLvl02.cpp
+++ b/src/game/magic/spells/SpellsLvl02.cpp
@@ -150,7 +150,9 @@ void DetectTrapSpell::Launch() {
 	
 	if(m_caster == EntityHandle_Player) {
 		m_target = m_caster;
-		if(!(m_flags & SPELLCAST_FLAG_NOSOUND)) {
+		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+		
+		if(emitsSound) {
 			ARX_SOUND_PlayInterface(g_snd.SPELL_DETECT_TRAP);
 			m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_DETECT_TRAP_LOOP, &m_caster_pos, 1.f);
 		}
@@ -165,8 +167,12 @@ void DetectTrapSpell::Launch() {
 
 void DetectTrapSpell::End() {
 	
-	ARX_SOUND_Stop(m_snd_loop);
-	m_snd_loop = audio::SourcedSample();
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_Stop(m_snd_loop);
+		m_snd_loop = audio::SourcedSample();
+	}
 	
 	m_targets.clear();
 }
@@ -195,9 +201,8 @@ void ArmorSpell::Launch()
 	
 	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_ARMOR_START, &entities[m_target]->pos);
+		m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_ARMOR_LOOP, &entities[m_target]->pos, 1.f);
 	}
-	
-	m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_ARMOR_LOOP, &entities[m_target]->pos, 1.f);
 	
 	if(m_caster == EntityHandle_Player) {
 		m_duration = 0;
@@ -221,13 +226,15 @@ void ArmorSpell::Launch()
 
 void ArmorSpell::End() {
 	
-	ARX_SOUND_Stop(m_snd_loop);
-	m_snd_loop = audio::SourcedSample();
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_Stop(m_snd_loop);
+		m_snd_loop = audio::SourcedSample();
+	}
 	
 	Entity * target = entities.get(m_target);
 	if(target) {
-		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
-		
 		if(emitsSound) {
 			ARX_SOUND_PlaySFX(g_snd.SPELL_ARMOR_END, &target->pos);
 		}
@@ -343,9 +350,8 @@ void HarmSpell::Launch() {
 	
 	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_HARM, &m_caster_pos);
+		m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_MAGICAL_SHIELD_LOOP, &m_caster_pos, 1.f);
 	}
-	
-	m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_MAGICAL_SHIELD_LOOP, &m_caster_pos, 1.f);
 	
 	spells.endByCaster(m_caster, SPELL_LIFE_DRAIN);
 	spells.endByCaster(m_caster, SPELL_MANA_DRAIN);
@@ -382,8 +388,12 @@ void HarmSpell::End() {
 	
 	m_cabal.end();
 	
-	ARX_SOUND_Stop(m_snd_loop);
-	m_snd_loop = audio::SourcedSample();
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_Stop(m_snd_loop);
+		m_snd_loop = audio::SourcedSample();
+	}
 }
 
 void HarmSpell::Update() {

--- a/src/game/magic/spells/SpellsLvl03.cpp
+++ b/src/game/magic/spells/SpellsLvl03.cpp
@@ -61,7 +61,11 @@ void SpeedSpell::Launch() {
 		m_target = m_caster;
 	}
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_SPEED_START, &entities[m_target]->pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_SPEED_START, &entities[m_target]->pos);
+	}
 	
 	if(m_target == EntityHandle_Player) {
 		m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_SPEED_LOOP, &entities[m_target]->pos, 1.f);
@@ -95,8 +99,10 @@ void SpeedSpell::End() {
 	ARX_SOUND_Stop(m_snd_loop);
 	m_snd_loop = audio::SourcedSample();
 	
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
 	Entity * target = entities.get(m_target);
-	if(target) {
+	if(target && emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_SPEED_END, &target->pos);
 	}
 	
@@ -128,7 +134,11 @@ Vec3f SpeedSpell::getPosition() const {
 
 void DispellIllusionSpell::Launch() {
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_DISPELL_ILLUSION);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_DISPELL_ILLUSION);
+	}
 	
 	m_duration = 1s;
 	m_hasDuration = true;
@@ -203,7 +213,12 @@ void FireballSpell::Launch() {
 	
 	eMove = angleToVector(Anglef(anglea, angleb, 0.f)) * 80.f;
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_LAUNCH, &m_caster_pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_LAUNCH, &m_caster_pos);
+	}
+	
 	m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_FIRE_WIND_LOOP, &m_caster_pos, 1.f);
 }
 
@@ -292,7 +307,13 @@ void FireballSpell::Update() {
 		
 		doSphericDamage(Sphere(eCurPos, 30.f * m_level), 3.f * m_level,
 		                DAMAGE_AREA, this, DAMAGE_TYPE_FIRE | DAMAGE_TYPE_MAGICAL, caster);
-		ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_HIT, &sphere.origin);
+		
+		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+		
+		if(emitsSound) {
+			ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_HIT, &sphere.origin);
+		}
+		
 		if(caster) {
 			spawnAudibleSound(sphere.origin, *caster);
 		}
@@ -312,7 +333,11 @@ CreateFoodSpell::CreateFoodSpell()
 
 void CreateFoodSpell::Launch() {
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_CREATE_FOOD, &m_caster_pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_CREATE_FOOD, &m_caster_pos);
+	}
 	
 	m_duration = (m_launchDuration >= 0) ? m_launchDuration : 3500ms;
 	m_hasDuration = true;
@@ -368,7 +393,11 @@ IceProjectileSpell::IceProjectileSpell()
 
 void IceProjectileSpell::Launch() {
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_ICE_PROJECTILE_LAUNCH, &m_caster_pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_ICE_PROJECTILE_LAUNCH, &m_caster_pos);
+	}
 	
 	m_duration = 4200ms;
 	m_hasDuration = true;

--- a/src/game/magic/spells/SpellsLvl03.cpp
+++ b/src/game/magic/spells/SpellsLvl03.cpp
@@ -65,10 +65,9 @@ void SpeedSpell::Launch() {
 	
 	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_SPEED_START, &entities[m_target]->pos);
-	}
-	
-	if(m_target == EntityHandle_Player) {
-		m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_SPEED_LOOP, &entities[m_target]->pos, 1.f);
+		if(m_target == EntityHandle_Player) {
+			m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_SPEED_LOOP, &entities[m_target]->pos, 1.f);
+		}
 	}
 	
 	if(m_caster == EntityHandle_Player) {
@@ -96,10 +95,12 @@ void SpeedSpell::End() {
 	
 	m_targets.clear();
 	
-	ARX_SOUND_Stop(m_snd_loop);
-	m_snd_loop = audio::SourcedSample();
-	
 	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_Stop(m_snd_loop);
+		m_snd_loop = audio::SourcedSample();
+	}
 	
 	Entity * target = entities.get(m_target);
 	if(target && emitsSound) {
@@ -217,15 +218,19 @@ void FireballSpell::Launch() {
 	
 	if(emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_LAUNCH, &m_caster_pos);
+		m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_FIRE_WIND_LOOP, &m_caster_pos, 1.f);
 	}
 	
-	m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_FIRE_WIND_LOOP, &m_caster_pos, 1.f);
 }
 
 void FireballSpell::End() {
 	
-	ARX_SOUND_Stop(m_snd_loop);
-	m_snd_loop = audio::SourcedSample();
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_Stop(m_snd_loop);
+		m_snd_loop = audio::SourcedSample();
+	}
 	
 	endLightDelayed(m_light, 500ms);
 }

--- a/src/game/magic/spells/SpellsLvl03.cpp
+++ b/src/game/magic/spells/SpellsLvl03.cpp
@@ -113,8 +113,13 @@ void SpeedSpell::End() {
 
 void SpeedSpell::Update() {
 	
-	if(m_caster == EntityHandle_Player)
-		ARX_SOUND_RefreshPosition(m_snd_loop, entities[m_target]->pos);
+	if(m_caster == EntityHandle_Player) {
+		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+		
+		if(emitsSound) {
+			ARX_SOUND_RefreshPosition(m_snd_loop, entities[m_target]->pos);
+		}
+	}
 	
 	for(SpeedTrail & trail : m_trails) {
 		Vec3f pos = entities[m_target]->obj->vertexWorldPositions[trail.vertexIndex].v;
@@ -301,6 +306,8 @@ void FireballSpell::Update() {
 		}
 	}
 	
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
 	Entity * caster = entities.get(m_caster);
 	if(!bExplo && CheckAnythingInSphere(sphere, caster, CAS_NO_SAME_GROUP)) {
 		spawnFireHitParticle(eCurPos, 0);
@@ -313,8 +320,6 @@ void FireballSpell::Update() {
 		doSphericDamage(Sphere(eCurPos, 30.f * m_level), 3.f * m_level,
 		                DAMAGE_AREA, this, DAMAGE_TYPE_FIRE | DAMAGE_TYPE_MAGICAL, caster);
 		
-		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
-		
 		if(emitsSound) {
 			ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_HIT, &sphere.origin);
 		}
@@ -325,7 +330,9 @@ void FireballSpell::Update() {
 		requestEnd();
 	}
 	
-	ARX_SOUND_RefreshPosition(m_snd_loop, eCurPos);
+	if(emitsSound) {
+		ARX_SOUND_RefreshPosition(m_snd_loop, eCurPos);
+	}
 }
 
 Vec3f FireballSpell::getPosition() const {

--- a/src/game/magic/spells/SpellsLvl04.cpp
+++ b/src/game/magic/spells/SpellsLvl04.cpp
@@ -58,7 +58,11 @@ void BlessSpell::Launch() {
 	
 	spells.endByCaster(m_target, SPELL_BLESS);
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_BLESS);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_BLESS);
+	}
 	
 	// TODO m_launchDuration is not used
 	// m_duration = (m_launchDuration > -1) ? m_launchDuration : 2000000;
@@ -209,10 +213,14 @@ void DispellFieldSpell::Launch() {
 		                     ANIM_TALK_NEUTRAL, ARX_SPEECH_FLAG_NOTEXT);
 	}
 	
-	if(dispelled > 0) {
-		ARX_SOUND_PlaySFX(g_snd.SPELL_DISPELL_FIELD);
-	} else {
-		ARX_SOUND_PlaySFX(g_snd.MAGIC_FIZZLE, &m_caster_pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		if(dispelled > 0) {
+			ARX_SOUND_PlaySFX(g_snd.SPELL_DISPELL_FIELD);
+		} else {
+			ARX_SOUND_PlaySFX(g_snd.MAGIC_FIZZLE, &m_caster_pos);
+		}
 	}
 }
 
@@ -236,7 +244,11 @@ void FireProtectionSpell::Launch() {
 		m_target = EntityHandle_Player;
 	}
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_PROTECTION, &entities[m_target]->pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_PROTECTION, &entities[m_target]->pos);
+	}
 	
 	m_fManaCostPerSecond = 1.f;
 	
@@ -249,17 +261,25 @@ void FireProtectionSpell::Launch() {
 	
 	m_targets.push_back(m_target);
 	
-	m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_FIRE_PROTECTION_LOOP, &entities[m_target]->pos, 1.f);
+	if(emitsSound) {
+		m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_FIRE_PROTECTION_LOOP, &entities[m_target]->pos, 1.f);
+	}
 }
 
 void FireProtectionSpell::End() {
 	
-	ARX_SOUND_Stop(m_snd_loop);
-	m_snd_loop = audio::SourcedSample();
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_Stop(m_snd_loop);
+		m_snd_loop = audio::SourcedSample();
+	}
 	
 	Entity * target = entities.get(m_target);
 	if(target) {
-		ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_PROTECTION_END, &target->pos);
+		if(emitsSound) {
+			ARX_SOUND_PlaySFX(g_snd.SPELL_FIRE_PROTECTION_END, &target->pos);
+		}
 		ARX_HALO_SetToNative(target);
 	}
 	
@@ -274,7 +294,11 @@ void FireProtectionSpell::Update() {
 		io->halo.color = Color3f(0.5f, 0.3f, 0.f);
 		io->halo.radius = 45.f;
 		
-		ARX_SOUND_RefreshPosition(m_snd_loop, io->pos);
+		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+		if(emitsSound) {
+			ARX_SOUND_RefreshPosition(m_snd_loop, io->pos);
+		}
 	}
 }
 
@@ -293,7 +317,11 @@ void ColdProtectionSpell::Launch() {
 		m_target = EntityHandle_Player;
 	}
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_COLD_PROTECTION_START, &entities[m_target]->pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_COLD_PROTECTION_START, &entities[m_target]->pos);
+	}
 	
 	if(m_caster == EntityHandle_Player) {
 		m_duration = 0;
@@ -312,19 +340,27 @@ void ColdProtectionSpell::Launch() {
 		io->halo.radius = 45.f;
 	}
 	
-	m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_COLD_PROTECTION_LOOP, &entities[m_target]->pos, 1.f);
+	if(emitsSound) {
+		m_snd_loop = ARX_SOUND_PlaySFX_loop(g_snd.SPELL_COLD_PROTECTION_LOOP, &entities[m_target]->pos, 1.f);
+	}
 	
 	m_targets.push_back(m_target);
 }
 
 void ColdProtectionSpell::End() {
 	
-	ARX_SOUND_Stop(m_snd_loop);
-	m_snd_loop = audio::SourcedSample();
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_Stop(m_snd_loop);
+		m_snd_loop = audio::SourcedSample();
+	}
 	
 	Entity * target = entities.get(m_target);
 	if(target) {
-		ARX_SOUND_PlaySFX(g_snd.SPELL_COLD_PROTECTION_END, &target->pos);
+		if(emitsSound) {
+			ARX_SOUND_PlaySFX(g_snd.SPELL_COLD_PROTECTION_END, &target->pos);
+		}
 		ARX_HALO_SetToNative(target);
 	}
 	
@@ -339,7 +375,11 @@ void ColdProtectionSpell::Update() {
 		io->halo.color = Color3f(0.2f, 0.2f, 0.45f);
 		io->halo.radius = 45.f;
 		
-		ARX_SOUND_RefreshPosition(m_snd_loop, io->pos);
+		bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+		if(emitsSound) {
+			ARX_SOUND_RefreshPosition(m_snd_loop, io->pos);
+		}
 	}
 }
 
@@ -361,7 +401,11 @@ void TelekinesisSpell::Launch() {
 		player.m_telekinesis = true;
 	}
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_TELEKINESIS_START, &m_caster_pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_TELEKINESIS_START, &m_caster_pos);
+	}
 }
 
 void TelekinesisSpell::End() {
@@ -369,8 +413,10 @@ void TelekinesisSpell::End() {
 	if(m_caster == EntityHandle_Player)
 		player.m_telekinesis = false;
 	
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
 	Entity * caster = entities.get(m_caster);
-	if(caster) {
+	if(caster && emitsSound) {
 		ARX_SOUND_PlaySFX(g_snd.SPELL_TELEKINESIS_END, &caster->pos);
 	}
 }
@@ -385,7 +431,11 @@ void CurseSpell::Launch() {
 	
 	spells.endByCaster(m_target, SPELL_CURSE);
 	
-	ARX_SOUND_PlaySFX(g_snd.SPELL_CURSE, &entities[m_target]->pos);
+	bool emitsSound = !(m_flags & SPELLCAST_FLAG_NOSOUND);
+	
+	if(emitsSound) {
+		ARX_SOUND_PlaySFX(g_snd.SPELL_CURSE, &entities[m_target]->pos);
+	}
 	
 	m_hasDuration = m_launchDuration >= 0;
 	m_duration = m_hasDuration ? m_launchDuration : 0;


### PR DESCRIPTION
Currently only 5 spells check whether the `SPELLCAST_FLAG_NOSOUND` flag is set. This addition adds support for all the sounds of all the spells.