### PR TITLE
AnimationRender: Allow texture tiling for entities

### DIFF
--- a/src/animation/AnimationRender.cpp
+++ b/src/animation/AnimationRender.cpp
@@ -117,7 +117,7 @@ static void PopOneTriangleList(RenderState baseState, TextureContainer * materia
 	baseState.setAlphaCutout(material->m_pTexture && material->m_pTexture->hasAlpha());
 	
 	UseRenderState state(baseState);
-	UseTextureState textureState(TextureStage::FilterLinear, TextureStage::WrapClamp);
+	UseTextureState textureState(TextureStage::FilterLinear, TextureStage::WrapRepeat);
 	
 	if(material->userflags & POLY_LATE_MIP) {
 		const float GLOBAL_NPC_MIPMAP_BIAS = -2.2f;
@@ -149,7 +149,7 @@ static void PopOneTriangleListTransparency(TextureContainer * material) {
 	}
 	
 	RenderState baseState = render3D().depthWrite(false);
-	UseTextureState textureState(TextureStage::FilterLinear, TextureStage::WrapClamp);
+	UseTextureState textureState(TextureStage::FilterLinear, TextureStage::WrapRepeat);
 	
 	GRenderer->SetTexture(0, material);
 	baseState.setAlphaCutout(material->m_pTexture && material->m_pTexture->hasAlpha());


### PR DESCRIPTION
This enables tiling/texture repeating for entities as it is currently only supported when applied to the terrain mesh, as seen on this image: (left one is part of the mesh, the right one is an entity)
![image](https://github.com/arx/ArxLibertatis/assets/2386064/cc7cb95b-9350-4de0-8dcc-da0967a0a662)
After the fix is applied it looks like this:
![image](https://github.com/arx/ArxLibertatis/assets/2386064/b31cff8f-33da-4d6c-ae95-03c82a29e28f)

This allows UV coordinates to go negative or over 1, which allows offsetting and scaling textures.