### PR TITLE
ScriptedIOProperties: Remove unused flag from HaloCommand

### DIFF
--- a/src/script/ScriptedIOProperties.cpp
+++ b/src/script/ScriptedIOProperties.cpp
@@ -447,7 +447,7 @@ public:
 		
 		Entity * io = context.getEntity();
 		
-		HandleFlags("ofnlcs") {
+		HandleFlags("ofncs") {
 		
 			if(flg & flag('o')) {
 				io->halo_native.flags |= HALO_ACTIVE;


### PR DESCRIPTION
`l` flag is not handled by the code nor is it present in any of the scripts