### PR TITLE
ScriptedNPC: Remove unused flags from behavior command

### DIFF
--- a/src/script/ScriptedNPC.cpp
+++ b/src/script/ScriptedNPC.cpp
@@ -71,7 +71,7 @@ public:
 		Entity * io = context.getEntity();
 		
 		Behaviour behavior = 0;
-		HandleFlags("lsdmfa012") {
+		HandleFlags("lsdmfa") {
 			behavior |= (flg & flag('l')) ? BEHAVIOUR_LOOK_AROUND : Behaviour(0);
 			behavior |= (flg & flag('s')) ? BEHAVIOUR_SNEAK : Behaviour(0);
 			behavior |= (flg & flag('d')) ? BEHAVIOUR_DISTANT : Behaviour(0);


### PR DESCRIPTION
`0`, `1` and `2` flags are never checked and they are not being used by any of the in-game scripts