### PR TITLE
Script CallStack, line and column  

### DIFF
--- a/src/script/ScriptUtils.h
+++ b/src/script/ScriptUtils.h
@@ -90,6 +90,9 @@ class Context {
 	ScriptMessage m_message;
 	ScriptParameters m_parameters;
 	std::vector<size_t> m_stack;
+	std::vector<size_t> m_stackCallFrom;
+	std::vector<std::string> m_stackId;
+	std::vector<size_t> m_vNewLineAt;
 	
 public:
 	
@@ -131,6 +134,8 @@ public:
 	
 	size_t getPosition() const { return m_pos; }
 	
+	std::string getPositionAndLineNumber(bool compact = false, size_t pos = static_cast<size_t>(-1)) const;
+	std::string getGoToGoSubCallStack(std::string_view prepend, std::string_view append) const;
 	
 };
 
@@ -181,7 +186,7 @@ bool isBlockEndSuprressed(const Context & context, std::string_view command);
 
 size_t initSuppressions();
 
-#define ScriptContextPrefix(context) '[' << ((context).getEntity() ? (((context).getScript() == &(context).getEntity()->script) ? (context).getEntity()->className() : (context).getEntity()->idString()) : "unknown") << ':' << (context).getPosition() << "] "
+#define ScriptContextPrefix(context) '[' << ((context).getEntity() ? (((context).getScript() == &(context).getEntity()->script) ? (context).getEntity()->className() : (context).getEntity()->idString()) : "unknown") << ':' << (context).getPositionAndLineNumber() << (context).getGoToGoSubCallStack(" (CallStack:", ")") << "] "
 #define ScriptPrefix ScriptContextPrefix(context) << getName() <<
 #define DebugScript(args) LogDebug(ScriptPrefix args)
 #define ScriptInfo(args) LogInfo << ScriptPrefix args

--- a/src/script/ScriptedInterface.cpp
+++ b/src/script/ScriptedInterface.cpp
@@ -202,6 +202,30 @@ std::ostream & operator<<(std::ostream & os, const PrintLocalVariables & data) {
 	return os;
 }
 
+static std::string getEventAndStackInfo(Context & context) {
+	std::stringstream s;
+	
+	if(context.getMessage() < SM_MAXCMD) {
+		s << " at Event " << ScriptEvent::name(context.getMessage());
+	}
+	
+	if(context.getSender()) {
+		s << " sent from " << context.getSender()->idString();
+	}
+	
+	if(context.getParameters().size() > 0) {
+		s << " with parameters (";
+		for(std::string s2 : context.getParameters()) {
+			s << s2 << " ";
+		}
+		s << ")";
+	}
+	
+	s << context.getGoToGoSubCallStack(" at GoTo/GoSub callStack ", ", " + context.getPositionAndLineNumber());
+	
+	return s.str();
+}
+
 class ShowLocalsCommand : public Command {
 	
 public:
@@ -212,8 +236,8 @@ public:
 		
 		DebugScript("");
 		
-		LogInfo << "Local variables for " << context.getEntity()->idString() << ":\n"
-		        << PrintLocalVariables(context.getEntity());
+		LogInfo << "Local variables for " << context.getEntity()->idString() << getEventAndStackInfo(context) << ":\n"
+			<< PrintLocalVariables(context.getEntity());
 		
 		return Success;
 	}
@@ -230,8 +254,8 @@ public:
 		
 		DebugScript("");
 		
-		LogInfo << "Local variables for " << context.getEntity()->idString() << ":\n"
-		        << PrintLocalVariables(context.getEntity());
+		LogInfo << "Local variables for " << context.getEntity()->idString() << getEventAndStackInfo(context) << ":\n"
+			<< PrintLocalVariables(context.getEntity());
 		LogInfo << "Global variables:\n" << PrintGlobalVariables();
 		
 		return Success;


### PR DESCRIPTION
Script CallStack, line and column  
logs will show more details for mod developers:  
- Warnings, Showlocals and showvars will show GoTo/GoSub call stack.  
- Showlocals and showvars will also show event and params  
- The script call stack now shows position, line and collumn from where each call was made  
Obs.: the column may not match your text editor as each tab on it may count as more than one column  

It now looks like ex.:  
```
[I] ScriptedInterface:257 Local variables for hologram_0004 at Event on main at GoTo/GoSub callStack functestcallstack1[p=30508,l=644,c=25] -> functestcallstack2[p=30175,l=626,c=25] -> functestcallstack3[p=30238,l=630,c=25] -> functestcallstack4[p=30301,l=634,c=25], [Position 30348, Line 638, Column 9]:
```

To test it:  
```
>>FUNCtestCallStack1 {
	GoSub FUNCtestCallStack2
	RETURN
}
>>FUNCtestCallStack2 {
	GoSub FUNCtestCallStack3
	RETURN
}
>>FUNCtestCallStack3 {
	GoSub FUNCtestCallStack4
	RETURN
}
>>FUNCtestCallStack4 {
	showvars //showlocals
	RETURN
}
On Main {
	GoSub FUNCtestCallStack1
	ACCEPT
}
```

<details>
  <summary>Obs.: about my other PR... branches</summary>
Obs.: I have many other PR_... branches, some are WIP but most are ready.  
If someone likes any of them, feel free to merge it in your own branch, test, improve etc. and create a pull request instead of me :).
There are also many usage examples and tests on the Hologram.asl script at my ArxLaetansMod (but it depends on my fully merged dev branch).
</details>
