### PR TITLE
ParticleEffects: improve particle position randomizer algorithm

### DIFF
--- a/src/graphics/particle/ParticleEffects.cpp
+++ b/src/graphics/particle/ParticleEffects.cpp
@@ -956,8 +956,10 @@ void TreatBackgroundActions() {
 			if(Random::getf() < light.ex_frequency) {
 				PARTICLE_DEF * pd = createParticle(true);
 				if(pd) {
-					float t = Random::getf() * glm::pi<float>();
-					Vec3f s = Vec3f(std::sin(t), std::sin(t), std::cos(t)) * arx::randomVec();
+					float tX = Random::getf() * glm::pi<float>();
+					float tY = Random::getf() * glm::pi<float>();
+					float tZ = Random::getf() * glm::pi<float>();
+					Vec3f s = Vec3f(std::cos(tX), std::cos(tY), std::cos(tZ)) * arx::randomVec();
 					pd->ov = light.pos + s * light.ex_radius;
 					pd->move = Vec3f(2.f, 2.f, 2.f) - Vec3f(4.f, 22.f, 4.f) * arx::randomVec3f();
 					pd->move *= light.ex_speed;


### PR DESCRIPTION
Using `sin()` for calculating the values of `s` vector will only fill half of the circle around the center, `cos()` goes into the negative territory aswell.

A little illustration on how it works incorrectly in current versions of arx:
![image](https://github.com/user-attachments/assets/47a5ba69-3e2a-41fb-9530-47412da59ea5)
![image](https://github.com/user-attachments/assets/fe7fc38a-0a54-455b-af79-fb49091863c2)
