### PR TITLE
Blender: Fix FTL export

### DIFF
--- a/plugins/blender/arx_addon/arx_io_model.py
+++ b/plugins/blender/arx_addon/arx_io_model.py
@@ -509,9 +509,9 @@ class ArxObjectManager(object):
             sels=sels
         )
 
-    def saveFile(self, path):
+    def saveFile(self, path, obj):
 
-        data = self.toFtlData()
+        data = self.toFtlData(obj)
 
         binData = self.ftlSerializer.write(data)
 

--- a/plugins/blender/arx_addon/main.py
+++ b/plugins/blender/arx_addon/main.py
@@ -201,7 +201,7 @@ class ExportFTL(bpy.types.Operator, ExportHelper):
 
     def execute(self, context):
         try:
-            getAddon(context).objectManager.saveFile(self.filepath)
+            getAddon(context).objectManager.saveFile(self.filepath, context.object)
             return {'FINISHED'}
         except ArxException as e:
             self.report({'ERROR'}, str(e))

--- a/plugins/blender/catalog.py
+++ b/plugins/blender/catalog.py
@@ -220,7 +220,7 @@ if args.data and args.out:
         bpy.context.scene.render.filepath = os.path.join(outPath, renderFile)
         bpy.ops.render.render(write_still=True)
 
-        arxAddon.objectManager.saveFile(fileName + ".test.ftl")
+        arxAddon.objectManager.saveFile(fileName + ".test.ftl", obj)
 
         obj.select = True
         bpy.ops.object.delete()


### PR DESCRIPTION
## Summary

- Pass the Blender object being exported through `saveFile()` to `toFtlData()`.
- Update the catalog helper call site to use the same export signature.

## Testing

- Compiled the changed Python files with Python's `compile()`.
- `git diff --check`
- `cmake --build <build-dir> --config RelWithDebInfo --parallel`
- `cmake --build <build-dir> --target style --config RelWithDebInfo`

Manual Blender export was not run locally.

Fixes [bug #1754](https://bugs.arx-libertatis.org/arx/issues/1754).